### PR TITLE
example genomics metadata

### DIFF
--- a/metadata/example/1KGP_chr1.json
+++ b/metadata/example/1KGP_chr1.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr1"
 	},

--- a/metadata/example/1KGP_chr1.json
+++ b/metadata/example/1KGP_chr1.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr1"
+	},
+	"title":"Chromosome 1",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"6056764"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"235061"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr10.json
+++ b/metadata/example/1KGP_chr10.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr10"
 	},

--- a/metadata/example/1KGP_chr10.json
+++ b/metadata/example/1KGP_chr10.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr10"
+	},
+	"title":"Chromosome 10",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3769238"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"144656"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr11.json
+++ b/metadata/example/1KGP_chr11.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr11"
 	},

--- a/metadata/example/1KGP_chr11.json
+++ b/metadata/example/1KGP_chr11.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr11"
+	},
+	"title":"Chromosome 11",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3793612"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"143588"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr12.json
+++ b/metadata/example/1KGP_chr12.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr12"
+	},
+	"title":"Chromosome 12",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3629625"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"146902"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr12.json
+++ b/metadata/example/1KGP_chr12.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr12"
 	},

--- a/metadata/example/1KGP_chr13.json
+++ b/metadata/example/1KGP_chr13.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr13"
+	},
+	"title":"Chromosome 13",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2705190"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"113204"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr13.json
+++ b/metadata/example/1KGP_chr13.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr13"
 	},

--- a/metadata/example/1KGP_chr14.json
+++ b/metadata/example/1KGP_chr14.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr14"
+	},
+	"title":"Chromosome 14",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2490590"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"99773"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr14.json
+++ b/metadata/example/1KGP_chr14.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr14"
 	},

--- a/metadata/example/1KGP_chr15.json
+++ b/metadata/example/1KGP_chr15.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr15"
 	},

--- a/metadata/example/1KGP_chr15.json
+++ b/metadata/example/1KGP_chr15.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr15"
+	},
+	"title":"Chromosome 15",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2273944"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"89809"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr16.json
+++ b/metadata/example/1KGP_chr16.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr16"
+	},
+	"title":"Chromosome 16",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2528069"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"84171"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr16.json
+++ b/metadata/example/1KGP_chr16.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr16"
 	},

--- a/metadata/example/1KGP_chr17.json
+++ b/metadata/example/1KGP_chr17.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr17"
+	},
+	"title":"Chromosome 17",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2143622"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"87646"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr17.json
+++ b/metadata/example/1KGP_chr17.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr17"
 	},

--- a/metadata/example/1KGP_chr18.json
+++ b/metadata/example/1KGP_chr18.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr18"
+	},
+	"title":"Chromosome 18",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"2151346"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"82396"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr18.json
+++ b/metadata/example/1KGP_chr18.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr18"
 	},

--- a/metadata/example/1KGP_chr19.json
+++ b/metadata/example/1KGP_chr19.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr19"
 	},

--- a/metadata/example/1KGP_chr19.json
+++ b/metadata/example/1KGP_chr19.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr19"
+	},
+	"title":"Chromosome 19",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"1648250"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"67728"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr2.json
+++ b/metadata/example/1KGP_chr2.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr2"
 	},

--- a/metadata/example/1KGP_chr2.json
+++ b/metadata/example/1KGP_chr2.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr2"
+	},
+	"title":"Chromosome 2",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"6689892"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"254832"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr20.json
+++ b/metadata/example/1KGP_chr20.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr20"
+	},
+	"title":"Chromosome 20",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"1702558"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"62847"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr20.json
+++ b/metadata/example/1KGP_chr20.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr20"
 	},

--- a/metadata/example/1KGP_chr21.json
+++ b/metadata/example/1KGP_chr21.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr21"
+	},
+	"title":"Chromosome 21",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"1037591"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"43733"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr21.json
+++ b/metadata/example/1KGP_chr21.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr21"
 	},

--- a/metadata/example/1KGP_chr22.json
+++ b/metadata/example/1KGP_chr22.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr22"
+	},
+	"title":"Chromosome 22",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"1019265"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"40550"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr22.json
+++ b/metadata/example/1KGP_chr22.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr22"
 	},

--- a/metadata/example/1KGP_chr3.json
+++ b/metadata/example/1KGP_chr3.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr3"
 	},

--- a/metadata/example/1KGP_chr3.json
+++ b/metadata/example/1KGP_chr3.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr3"
+	},
+	"title":"Chromosome 3",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"5510472"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"213759"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr4.json
+++ b/metadata/example/1KGP_chr4.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr4"
+	},
+	"title":"Chromosome 4",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"5430270"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"217157"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr4.json
+++ b/metadata/example/1KGP_chr4.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr4"
 	},

--- a/metadata/example/1KGP_chr5.json
+++ b/metadata/example/1KGP_chr5.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr5"
+	},
+	"title":"Chromosome 5",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"4978871"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"196285"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr5.json
+++ b/metadata/example/1KGP_chr5.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr5"
 	},

--- a/metadata/example/1KGP_chr6.json
+++ b/metadata/example/1KGP_chr6.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr6"
 	},

--- a/metadata/example/1KGP_chr6.json
+++ b/metadata/example/1KGP_chr6.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr6"
+	},
+	"title":"Chromosome 6",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"4732160"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"193158"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr7.json
+++ b/metadata/example/1KGP_chr7.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr7"
+	},
+	"title":"Chromosome 7",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"4450904"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"170788"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr7.json
+++ b/metadata/example/1KGP_chr7.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr7"
 	},

--- a/metadata/example/1KGP_chr8.json
+++ b/metadata/example/1KGP_chr8.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr8"
+	},
+	"title":"Chromosome 8",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"4368964"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"151538"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chr8.json
+++ b/metadata/example/1KGP_chr8.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr8"
 	},

--- a/metadata/example/1KGP_chr9.json
+++ b/metadata/example/1KGP_chr9.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chr9"
 	},

--- a/metadata/example/1KGP_chr9.json
+++ b/metadata/example/1KGP_chr9.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chr9"
+	},
+	"title":"Chromosome 9",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3355633"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"124138"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chrMT.json
+++ b/metadata/example/1KGP_chrMT.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chrMT"
 	},

--- a/metadata/example/1KGP_chrMT.json
+++ b/metadata/example/1KGP_chrMT.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chrMT"
+	},
+	"title":"Mitochondrial genome",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-10-02 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3587"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"20"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": ""
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chrX.json
+++ b/metadata/example/1KGP_chrX.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chrX"
+	},
+	"title":"Chromosome X",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"3191768"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"210679"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chrX.json
+++ b/metadata/example/1KGP_chrX.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chrX"
 	},

--- a/metadata/example/1KGP_chrY.json
+++ b/metadata/example/1KGP_chrY.json
@@ -1,0 +1,60 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier": "1KGP_chrY"
+	},
+	"title":"Chromosome Y",
+	"dates": [
+		{
+			"type": {
+				"value":"source .vcf file creation date"
+			},
+			"date": "2015-02-18 00:00:00"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"storedIn": {
+		"name": "https://datahub-khvul4ng.udes.genap.ca/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
+		"description": "Gzipped .vcf file containing sequence variations"
+	},
+	"dimensions": [
+		{
+			"name": {
+				"value": "Count of Single Nucleotide Polymorphism variants"
+			},
+			"values": [
+				"60505"
+			]
+		},
+		{
+			"name": {
+				"value": "Count of single-nucleotide insertion and deletion events"
+			},
+			"values": [
+				"1314"
+			]
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+			"values": [
+				{
+					"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+				}
+			]
+		}
+	]
+}

--- a/metadata/example/1KGP_chrY.json
+++ b/metadata/example/1KGP_chrY.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier": "1KGP_chrY"
 	},

--- a/metadata/example/1KGP_master.json
+++ b/metadata/example/1KGP_master.json
@@ -1,6 +1,11 @@
 {
 	"version": "1.0",
 	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "to be determined"
+		}
+	],
 	"identifier": {
 		"identifier" : "1KGP"
 	},
@@ -55,7 +60,7 @@
 			"type": {
 				"value":"CONP DATS JSON fileset creation date"
 			},
-			"date": "2019-04-01 12:43:32"
+			"date": "2019-04-01 14:23:21"
 		}
 	],
 	"hasPart": [

--- a/metadata/example/1KGP_master.json
+++ b/metadata/example/1KGP_master.json
@@ -1,0 +1,513 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"identifier": {
+		"identifier" : "1KGP"
+	},
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"title": "1000 Genomes Project",
+	"storedIn": {
+		"name" : "Canadian Centre for Computational Genomics"
+	},
+	"primaryPublications" : [
+		{
+			"identifier": {
+				"identifier": "https://doi.org/10.1038/nature15393"
+			},
+			"title": "A global reference for human genetic variation",
+			"dates": [
+				{
+					"type": {
+						"value":"Primary reference publication date"
+					},
+					"date": "2015-10-01 00:00:00"
+				}
+			],
+			"authors": [
+				{
+				"name":"1000 Genomes Project"
+				}
+			]
+		}
+	],
+	"isAbout": [
+		{
+			"identifier": {
+				"identifier": "9606",
+				"identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/9606"
+			},
+			"name":"Homo sapiens"
+		}
+	],
+	"dates": [
+		{
+			"type": {
+				"value":"CONP DATS JSON fileset creation date"
+			},
+			"date": "2019-04-01 12:43:32"
+		}
+	],
+	"hasPart": [
+		{
+			"identifier": {
+				"identifier": "1KGP_chr1.json"
+			},
+			"title":"Chromosome 1",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr10.json"
+			},
+			"title":"Chromosome 10",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr11.json"
+			},
+			"title":"Chromosome 11",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr12.json"
+			},
+			"title":"Chromosome 12",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr13.json"
+			},
+			"title":"Chromosome 13",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr14.json"
+			},
+			"title":"Chromosome 14",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr15.json"
+			},
+			"title":"Chromosome 15",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr16.json"
+			},
+			"title":"Chromosome 16",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr17.json"
+			},
+			"title":"Chromosome 17",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr18.json"
+			},
+			"title":"Chromosome 18",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr19.json"
+			},
+			"title":"Chromosome 19",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr2.json"
+			},
+			"title":"Chromosome 2",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr20.json"
+			},
+			"title":"Chromosome 20",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr21.json"
+			},
+			"title":"Chromosome 21",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr22.json"
+			},
+			"title":"Chromosome 22",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr3.json"
+			},
+			"title":"Chromosome 3",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr4.json"
+			},
+			"title":"Chromosome 4",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr5.json"
+			},
+			"title":"Chromosome 5",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr6.json"
+			},
+			"title":"Chromosome 6",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr7.json"
+			},
+			"title":"Chromosome 7",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr8.json"
+			},
+			"title":"Chromosome 8",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chr9.json"
+			},
+			"title":"Chromosome 9",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chrMT.json"
+			},
+			"title":"Mitochondrial genome",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chrX.json"
+			},
+			"title":"Chromosome X",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		},
+		{
+			"identifier": {
+				"identifier": "1KGP_chrY.json"
+			},
+			"title":"Chromosome Y",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This update adds 26 files of metadata for 1000 Genomes Project data provided by David Bujold at C3G, which document variation between 1093 human genome sequences.   One of these is a master file, and 25 contain metadata for individual chromosomes (1-22, X, Y, and the mitochondrial genome).  File structure has been validated against the DATS dataset_schema.json file from the bioCADDIE GitHub repository.  The metadata for each individual chromosome include names, file creation dates, locations for the zipped .vcf file containing the underlying data,  summary statistics of the single-nucleotide polymorphisms and insertion/deletion events recorded in each .vcf file, and  an "extraProperties" entry providing a link to the reference sequence for each chromosome.  The master file includes a primary publication reference, formal taxonomic identification, and an appropriately formatted list of the part files.  Design here principally by EOB, with input from JB and Jennifer at the MONII hackathon.