### PR TITLE
Improving community guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at conp-tsc@googlegroups.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,10 +4,12 @@ New contributions are more than welcome! ❤️
 
 ## Contribution workflow
 
-Whether you are planning to add
-a new dataset, add data to an existing one, or simply fix a typo or a bug
-wherever in this repository, you will have to follow the following workflow:
+You should perform the workflow below if:
+ 1. you are planning to add a new dataset
+ 2. you are adding data to an already existing dataset
+ 3. you are making any changes (e.g. fixing a typo or a bug)
 
+Please perform the following steps:
 1. Fork this repository, or make that your existing fork is up-to-date.
 2. Clone your fork on your local computer, or make sure that your existing clone
 is up-to-date.
@@ -16,13 +18,13 @@ is up-to-date.
 5. Open a pull request (PR) to the main repository.
 For steps 3. and 4., see detailed instructions in the sections below.
 
-This follows a very common GitHub workflow. If you are not familiar with
-it, we suggest to read [GitHub documentation](https://help.github.com/en),
+If you are not familiar with
+these steps, we suggest to read [GitHub documentation](https://help.github.com/en),
 in particular the articles on [forks]
 (https://help.github.com/en/articles/working-with-forks) and [pull
 requests](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
 
-Your PR will be reviewed by two members of our technical team. They will
+Your PR will be reviewed by at least two members of our technical team. They will
 make sure that your contribution meets the quality standards for inclusion
 in this repository. Refer to the [PR
 template](https://github.com/CONP-PCNO/conp-dataset/.github/PULL_REQUEST_TEMPLATE.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contribution			
+
+New contributions are more than welcome! ❤️ 
+
+## Contribution workflow
+
+Whether you are planning to add
+a new dataset, add data to an existing one, or simply fix a typo or a bug
+wherever in this repository, you will have to follow the following workflow:
+
+1. Fork this repository, or make that your existing fork is up-to-date.
+2. Clone your fork on your local computer, or make sure that your existing clone
+is up-to-date.
+3. Edit your local clone, and commit your changes using `datalad save`.
+4. Push your changes to your fork using `datalad publish`.
+5. Open a pull request (PR) to the main repository.
+For steps 3. and 4., see detailed instructions in the sections below.
+
+This follows a very common GitHub workflow. If you are not familiar with
+it, we suggest to read [GitHub documentation](https://help.github.com/en),
+in particular the articles on [forks]
+(https://help.github.com/en/articles/working-with-forks) and [pull
+requests](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
+
+Your PR will be reviewed by two members of our technical team. They will
+make sure that your contribution meets the quality standards for inclusion
+in this repository. Refer to the [PR
+template](https://github.com/CONP-PCNO/conp-dataset/.github/PULL_REQUEST_TEMPLATE.md)
+for more information about PR evaluations.
+
+## Adding data
+
+You can create a 
+sub-dataset in the CONP repository as follows:
+
+1. Create your sub-dataset in your cloned fork, under `investigators` or `projects`. For instance:
+
+```console
+datalad create -d . investigators/<username>
+```
+
+2. Publish your sub-dataset:
+
+    From the main repository (`conp-dataset`):
+
+    a. Add a sibling for your dataset on GitHub:
+
+    ```console
+    datalad create-sibling-github -d investigators/<username> conp-dataset-<username>
+    ```
+
+    DataLad will ask your GitHub user name and password to create the sibling.
+
+    b. Update the `.gitmodules` file to add your sibling. It should contain a section that looks like this:
+
+    ```
+    [submodule "investigators/<username>"]
+        path = investigators/<username>
+        url = http://github.com:<username>/conp-dataset-<username>.git
+    ```
+
+    Note the Git endpoint in the url.
+
+3. Add files to your sub-dataset:
+
+    From your sub-dataset (`investigators/<username>`):
+    
+    a. Create and add a README.md file, directly in the Git repository:
+    ```console
+    datalad add --to-git ./README.md
+    ```
+
+    b. Add data files:
+    * Files that are already accessible through http:
+    ```console
+    git annex addurl <url> --file <local_path>
+    ```
+
+    * Files that you want to make available through Google Drive:
+    ```console
+    pip install git+https://github.com/glatard/git-annex-remote-googledrive.git@dev
+    git-annex-remote-googledrive setup
+    git annex initremote google type=external externaltype=googledrive prefix=CONP-data root_id=<folder_id> chunk=50MiB encryption=shared mac=HMACSHA512
+    ```
+    where `<folder_id>` is the id of the Google Drive folder where you want to upload the files. Don't forget to 
+    check the permissions of this folder, for instance, make it world-readable if you want your files to be
+    world readable. Assuming that you want to add image.nii.gz to the dataset:
+    ```console
+    datalad add image.nii.gz
+    git annex copy image.nii.gz --to google
+    ```
+
+    c. Publish the modifications:
+    ```console
+    datalad save
+    datalad publish --to github
+    ```
+    
+4. Publish the modifications to your fork of the main dataset:
+
+    From the main repository (`conp-dataset`):
+    ```console
+    datalad save
+    datalad publish --to origin
+    ```
+
+## Adding meta-data
+
+Adding meta-data about your dataset is required. Metadata has to be added in 
+a JSON file with the following attributes based on [bioCADDIE
+DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
+- schema
+- title
+- description
+- dates
+- creators
+- storedIn
+- type
+- version
+- privacy
+- licenses
+Examples are available at [metadata/example](metadata/example).
+
+## Re-using existing data
+
+You can reuse any published dataset in your own dataset. For instance,
+to add data from the [CoRR](http://fcon_1000.projects.nitrc.org/indi/CoRR/html):
+```
+datalad install -d . --source ///corr/RawDataBIDS CorrBIDS
+```
+Datasets available in DataLad are listed [here](http://datasets.datalad.org).
+

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Description of the bug'
+labels: bug
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen. Add an example with all 
+ the information needed to reproduce the bug (descriptors, inputs, etc) -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior. Add an example with all 
+ the information needed to reproduce the bug (descriptors, inputs, etc) -->
+
+## Environment (optional)
+<!--- Information about the execution environment, in particular: Python version, Docker/Singularity version
+ if relevant -->
+
+## Context (optional)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Possible fix (optional)
+<!--- Not obligatory, but suggest an idea to fix the prroblem -->
+
+## Related issues (optional)
+<!--- Link any related issue -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'Description of the feature'
+labels: enhancement
+assignees: ''
+
+---
+
+## Purpose
+<!--- A clear and concise description of the proposed new feature. -->
+
+## Context
+<!-- Why the new feature would be useful -->
+
+## Possible Implementation (optional)
+<!--- Not obligatory, but suggest an idea for implementing the new feature-->
+
+## Related issues (optional)
+<!-- Link any related issue-->

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Canadian Open Neuroscience Platform. It leverages
 data files distributed in various storage spaces and accessible depending on each data owner's 
 policy.
 
+The instructions below explain how to find and get data from the dataset.
+You can also add data by following the instructions in our [contribution
+guidelines](https://github.com/CONP-PCNO/conp-dataset/.github/CONTRIBUTING.md).
 We welcome your feedback! :smiley:
 
 ## Dataset structure
 
 The dataset is structured as follows:
 
-* `investigators` contains sub-datasets for investigators based in Canada.
-* `projects` contains sub-datasets for projects hosted in Canada.
+* `investigators` contains sub-datasets for investigators.
+* `projects` contains sub-datasets for projects.
 
 Investigators and projects are responsible for the management and curation 
 of their own sub-datasets.
@@ -24,9 +27,9 @@ of their own sub-datasets.
 * [Git annex](http://git-annex.branchable.com/install)
 * DataLad: `pip install git+https://github.com/datalad/datalad.git`
 
-## Accessing data
+## Getting the data
 
-To start, install the main CONP dataset on your computer:
+Install the main CONP dataset on your computer:
 
 ```console
 datalad install -r http://github.com/CONP-PCNO/conp-dataset
@@ -45,170 +48,3 @@ You can also search for relevant files and sub-datasets as follows:
 ```console
 datalad search T1
 ```
-
-
-## Adding data
-
-If you are an investigator or a project manager, you can create a 
-sub-dataset in the CONP repository as follows:
-
-1. Fork the CONP data repository on GitHub:
-   * Navigate to http://github.com/CONP-PCNO/conp-dataset (this page)
-   * In the top-right corner of the page, click Fork. 
-   * This will create a copy of the dataset at http://github.com:username/conp-dataset
-
-2. Install your fork on your computer:
-
-```console
-datalad install git@github.com:<username>/conp-dataset
-```
-
-3. Create your sub-dataset in your cloned fork, under `investigators` or `projects`. For instance:
-
-```console
-datalad create -d . investigators/<username>
-```
-
-4. Publish your sub-dataset:
-
-    From the main repository (`conp-dataset`):
-
-    a. Add a sibling for your dataset on GitHub:
-
-    ```console
-    datalad create-sibling-github -d investigators/<username> conp-dataset-<username>
-    ```
-
-    DataLad will ask your GitHub user name and password to create the sibling.
-
-    b. Update the `.gitmodules` file to add your sibling. It should contain a section that looks like this:
-
-    ```
-    [submodule "investigators/<username>"]
-        path = investigators/<username>
-        url = http://github.com:<username>/conp-dataset-<username>.git
-    ```
-
-    Note the Git endpoint in the url.
-
-5. Add files to your sub-dataset:
-
-    From your sub-dataset (`investigators/<username>`):
-    
-    a. Create and add a README.md file, directly in the Git repository:
-    ```console
-    datalad add --to-git ./README.md
-    ```
-
-    b. Add data files:
-    * Files that are already accessible through http:
-    ```console
-    git annex addurl <url> --file <local_path>
-    ```
-
-    * Files that you want to make available through Google Drive:
-    ```console
-    pip install git+https://github.com/glatard/git-annex-remote-googledrive.git@dev
-    git-annex-remote-googledrive setup
-    git annex initremote google type=external externaltype=googledrive prefix=CONP-data root_id=<folder_id> chunk=50MiB encryption=shared mac=HMACSHA512
-    ```
-    where `<folder_id>` is the id of the Google Drive folder where you want to upload the files. Don't forget to 
-    check the permissions of this folder, for instance, make it world-readable if you want your files to be
-    world readable. Assuming that you want to add image.nii.gz to the dataset:
-    ```console
-    datalad add image.nii.gz
-    git annex copy image.nii.gz --to google
-    ```
-
-    c. Publish the modifications:
-    ```console
-    datalad save
-    datalad publish --to github
-    ```
-    
-7. Publish the modifications to your fork of the main dataset:
-
-    From the main repository (`conp-dataset`):
-    ```console
-    datalad save
-    datalad publish --to origin
-    ```
-
-8. Publish modifications to the main dataset:
-
-    Create a new pull request from http://github.com:username/conp-dataset to http://github.com/CONP-PCNO/conp-dataset.
-
-    TODO: add a screenshot here.
-
-Once the pull request is accepted by the CONP data managers, your 
-dataset is created in the CONP repository. It is then up to you to manage its content and 
-decide on the creation of sub-datasets in it. Modifications to 
-your dataset can be propagated to the CONP dataset through pull 
-requests, by repeating the last step above.
-
-## dataset meta-data
-
-Adding meta-data about your dataset is recommended. Although there is no standard yet for CONP, preliminary work favor a JSON file with the following attributes based on [bioCADDIE DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
-- schema
-- title
-- description
-- dates
-- creators
-- storedIn
-- type
-- version
-- privacy
-- licenses
-
-example are available at [metadata/example](metadata/example).
-
-## Re-using existing data
-
-You can easily reuse any published dataset in your own dataset. For instance,
-to add data from the [CoRR](http://fcon_1000.projects.nitrc.org/indi/CoRR/html):
-```
-datalad install -d . --source ///corr/RawDataBIDS CorrBIDS
-```
-Datasets available in DataLad are listed [here](http://datasets.datalad.org).
-
-
-# Pull Request workflow
-
-To test a PR that proposes the addition of a new dataset, this is a possible workflow:
-
-1. To create the PR, you should work on your fork of of conp-dataset (eg github://jbpoline/conp-dataset)
-
-2. Ensure your fork master branch is not ahead of github://conp-pcno/conp-dataset master branch
-
-3. Clone your fork locally, eg 
-```
-mkdir myfork-of-conp-dataset
-cd myfork-of-conp-dataset
-git clone git@github.com:<mygithubhandle>/conp-dataset.git
-```
-(eg mygithubhandle is jbpoline)
-
-4. Add the remote from which the PR comes from (unless it comes from a branch of conp-dataset), for instance if the PR comes from the `myfriend-fork` github handle (and check that the remote is added):
-```
-git remote add myfriend-fork git@github.com:myfriend-fork/conp-dataset.git
-git remote -vv 
-``` 
-
-5. Pull the pull request to your local fork, for instance if it is in master of `myfriend-fork`: 
-```
-git pull myfriend-fork master
-```
-
-6. Push to your local fork in master
-git push origin master:master
-
-7. Datalad install this 
-```
-datalad install -r https://github.com/<mygithubhandle>/conp-dataset.git
-```
-
-8. Check there that all is fine:
-- the `git annex whereis` is giving sensible urls
-- the `datalad get` work for open data
-- ...
-


### PR DESCRIPTION
This PR improves our community guidelines based on [GitHub's suggestions](https://github.com/CONP-PCNO/conp-dataset/community). More specifically, it adds:
* A code of conduct, identical to [the one in conp-portal](https://github.com/CONP-PCNO/conp-portal/blob/master/.github/CODE_OF_CONDUCT.md).
* A contribution guide, describing how to add a dataset, including the forking and PR procedure. The corresponding instructions in README.md have been updated accordingly. README.md now focuses on instructions on how to use the dataset.
* Issue templates, identical to the ones in conp-portal.

A PR template was already proposed in #50. Licensing will be discussed in a separate issue.