### PR TITLE
Documentation fixes and suggestions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution			
 
-New contributions are more than welcome! ❤️ 
+New contributions are more than welcome! ❤️
 
 ## Contribution workflow
 
@@ -10,7 +10,7 @@ You should perform the workflow below if:
  3. you are making any changes (e.g. fixing a typo or a bug)
 
 Please perform the following steps:
-1. Fork this repository, or make that your existing fork is up-to-date.
+1. Fork this repository, or make sure that your existing fork is up-to-date.
 2. Clone your fork on your local computer, or make sure that your existing clone
 is up-to-date.
 3. Edit your local clone, and commit your changes using `datalad save`.
@@ -32,7 +32,7 @@ for more information about PR evaluations.
 
 ## Adding data
 
-You can create a 
+You can create a
 sub-dataset in the CONP repository as follows:
 
 1. Create your sub-dataset in your cloned fork, under `investigators` or `projects`. For instance:
@@ -66,7 +66,7 @@ datalad create -d . investigators/<username>
 3. Add files to your sub-dataset:
 
     From your sub-dataset (`investigators/<username>`):
-    
+
     a. Create and add a README.md file, directly in the Git repository:
     ```console
     datalad add --to-git ./README.md
@@ -84,7 +84,7 @@ datalad create -d . investigators/<username>
     git-annex-remote-googledrive setup
     git annex initremote google type=external externaltype=googledrive prefix=CONP-data root_id=<folder_id> chunk=50MiB encryption=shared mac=HMACSHA512
     ```
-    where `<folder_id>` is the id of the Google Drive folder where you want to upload the files. Don't forget to 
+    where `<folder_id>` is the id of the Google Drive folder where you want to upload the files. Don't forget to
     check the permissions of this folder, for instance, make it world-readable if you want your files to be
     world readable. Assuming that you want to add image.nii.gz to the dataset:
     ```console
@@ -97,7 +97,7 @@ datalad create -d . investigators/<username>
     datalad save
     datalad publish --to github
     ```
-    
+
 4. Publish the modifications to your fork of the main dataset:
 
     From the main repository (`conp-dataset`):
@@ -108,7 +108,7 @@ datalad create -d . investigators/<username>
 
 ## Adding meta-data
 
-Adding meta-data about your dataset is required. Metadata has to be added in 
+Adding meta-data about your dataset is required. Metadata has to be added in
 a JSON file with the following attributes based on [bioCADDIE
 DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
 - schema
@@ -121,7 +121,7 @@ DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
 - version
 - privacy
 - licenses
-Examples are available at [metadata/example](metadata/example).
+Examples are available at [metadata/example](https://github.com/CONP-PCNO/conp-dataset/tree/master/metadata/example).
 
 ## Re-using existing data
 
@@ -131,4 +131,3 @@ to add data from the [CoRR](http://fcon_1000.projects.nitrc.org/indi/CoRR/html):
 datalad install -d . --source ///corr/RawDataBIDS CorrBIDS
 ```
 Datasets available in DataLad are listed [here](http://datasets.datalad.org).
-

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,8 +32,7 @@ for more information about PR evaluations.
 
 ## Adding data
 
-You can create a
-sub-dataset in the CONP repository as follows:
+You can create a sub-dataset in the CONP repository as follows:
 
 1. Create your sub-dataset in your cloned fork, under `investigators` or `projects`. For instance:
 
@@ -121,6 +120,7 @@ DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
 - version
 - privacy
 - licenses
+
 Examples are available at [metadata/example](https://github.com/CONP-PCNO/conp-dataset/tree/master/metadata/example).
 
 ## Re-using existing data


### PR DESCRIPTION
Made a few changes to the documentation, as well as some suggestions based on the CONTRIBUTING document and from a previous attempt at adding a dataset (might be better fitted to create issues for them?). 

## Changes
- Added a missing word to instructions under "Contribution workflow" heading
- Fix spacing under "Adding meta-data" heading
- Update URL to `metadata/example`
  - Previous URL did not work - not sure if this was intent until metadata is formalized

## Suggestions
- Intended audience for the document, and what is there experience?
  - Maybe move the suggestion about reading GitHub documentation prior to the workflow heading (since there appears to be an underlying assumption of knowing how to use git. 
  - Where should a user go / who to contact if there is an issue - post under issues in the repo? Would have a help or contact section near the top for the above notes
- Instructions for "Adding Data"
  - There seems to be a few different instructions regarding adding a sub-module in different documentations. Again, this could be due to the underlying assumption of git. Had some issues when I was originally setting up the sub-module for the Khanlab datasets. Think it would be good if the documents had the same instructions for the sub-modules.
  - Is there documentation available from potentially different sources (eg. aws, osf, etc.) that be linked to? Depending on the target audience, maybe there should be a note that the files need to be hosted somewhere (unless there is available space for this). 
- Current instructions can also appear to imply a binary workflow - either it is already hosted somewhere (https) or to host through Google Drive, which can be potentially problematic. Suggestion would be to link to a folder of documentations that help walk the user in adding their data using their source. This does not need to be how to host the files, but just how to add from the source (eg. aws, osf, etc.) Additionally, this might help to provide some clearer instructions for users to contribute their dataset.