### PR TITLE
Improvements to contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ datalad create -d . investigators/<username>
 Adding meta-data about your dataset is required. Metadata has to be added
 in a JSON file called `dats.json`, located at the root of your dataset, and
 containing the following attributes based on [bioCADDIE
-DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
+DATS](https://github.com/datatagsuite/schema):
 - schema
 - title
 - description

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -148,6 +148,8 @@ c. Release your dataset on GitHub (see instructions
 d. This will create a DOI and archive your dataset on Zenodo. Get the DOI
 badge from [here](https://zenodo.org/account/settings/github/) and add it
 to the `README.md` file of your dataset.
+e. The DOI badge links to the DOI associated with the latest DOI of your dataset. 
+   Add this link to your DATS model.
 
 ## Re-using existing data
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 New contributions are more than welcome! ❤️
 
+Before you start, we suggest that you get familiar with git and GitHub
+ as our contribution workflow heavily relies on these tools. If
+you have never used git, a good quick start guide is available
+[here](https://rogerdudler.github.io/git-guide). If you're looking for more
+comprehensive training, you can check [this](https://try.github.io) out.
+GitHub guides are available [here](https://guides.github.com). We will also
+refer to specific sections of them in the instructions below.
+
+One last thing before we start: if you need help at any stage, please [open
+an issue](https://github.com/CONP-PCNO/conp-dataset/issues/new/choose) in
+this repository. We'll do our best to help you!
+
 ## Contribution workflow
 
 You should perform the workflow below if:
@@ -10,20 +22,15 @@ You should perform the workflow below if:
  3. you are making any changes (e.g. fixing a typo or a bug)
 
 Please perform the following steps:
-1. Fork this repository, or make sure that your existing fork is up-to-date.
+1. [Fork](https://help.github.com/en/articles/working-with-forks) this repository, or make sure that your existing fork is up-to-date.
 2. Clone your fork on your local computer, or make sure that your existing clone
 is up-to-date.
 3. Edit your local clone, and commit your changes using `datalad save`.
 4. Push your changes to your fork using `datalad publish`.
 5. Get a DOI for your dataset.
-6. Open a pull request (PR) to the main repository.
+6. Open a [pull
+request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) (PR) to the main repository.
 For steps 3., 4. and 5., see detailed instructions in Section "Adding data" below.
-
-If you are not familiar with
-these steps, we suggest to read [GitHub documentation](https://help.github.com/en),
-in particular the articles on [forks]
-(https://help.github.com/en/articles/working-with-forks) and [pull
-requests](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
 
 Your PR will be reviewed by at least two members of our technical team. They will
 make sure that your contribution meets the quality standards for inclusion

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,8 +15,9 @@ Please perform the following steps:
 is up-to-date.
 3. Edit your local clone, and commit your changes using `datalad save`.
 4. Push your changes to your fork using `datalad publish`.
-5. Open a pull request (PR) to the main repository.
-For steps 3. and 4., see detailed instructions in the sections below.
+5. Get a DOI for your dataset.
+6. Open a pull request (PR) to the main repository.
+For steps 3., 4. and 5., see detailed instructions in Section "Adding data" below.
 
 If you are not familiar with
 these steps, we suggest to read [GitHub documentation](https://help.github.com/en),
@@ -97,19 +98,12 @@ datalad create -d . investigators/<username>
     datalad save
     datalad publish --to github
     ```
-    
-4. Publish the modifications to your fork of the main dataset:
 
-    From the main repository (`conp-dataset`):
-    ```console
-    datalad save
-    datalad publish --to origin
-    ```
+4. Add metadata to your dataset
 
-## Adding meta-data
-
-Adding meta-data about your dataset is required. Metadata has to be added in 
-a JSON file with the following attributes based on [bioCADDIE
+Adding meta-data about your dataset is required. Metadata has to be added
+in a JSON file called `dats.json`, located at the root of your dataset, and
+containing the following attributes based on [bioCADDIE
 DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
 - schema
 - title
@@ -123,6 +117,31 @@ DATS](https://github.com/biocaddie/WG3-MetadataSpecifications):
 - licenses
 Examples are available at [metadata/example](metadata/example).
 
+5. Publish the modifications to your fork of the main dataset:
+
+    From the main repository (`conp-dataset`):
+    ```console
+    datalad save
+    datalad publish --to origin
+    ```
+
+6. Get a Digital Object Identifier for your dataset
+
+Datasets in CONP are required to have a Digital Object Identifier (DOI). A
+DOI is a unique and permanent identifier associated with a research object
+to make it citeable and retrievable. To get a DOI for your dataset, follow
+the following steps:
+
+a. Log in to [Zenodo](https://zenodo.org), preferably using your GitHub
+account.
+b. [Flip the switch](https://zenodo.org/account/settings/github) of your
+dataset GitHub repository.
+c. Release your dataset on GitHub (see instructions
+[here](https://help.github.com/en/articles/creating-releases)).
+d. This will create a DOI and archive your dataset on Zenodo. Get the DOI
+badge from [here](https://zenodo.org/account/settings/github/) and add it
+to the `README.md` file of your dataset.
+
 ## Re-using existing data
 
 You can reuse any published dataset in your own dataset. For instance,
@@ -131,4 +150,3 @@ to add data from the [CoRR](http://fcon_1000.projects.nitrc.org/indi/CoRR/html):
 datalad install -d . --source ///corr/RawDataBIDS CorrBIDS
 ```
 Datasets available in DataLad are listed [here](http://datasets.datalad.org).
-

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You should perform the workflow below if:
  3. you are making any changes (e.g. fixing a typo or a bug)
 
 Please perform the following steps:
-1. [Fork](https://help.github.com/en/articles/working-with-forks) this repository, or make sure that your existing fork is up-to-date.
+1. [Fork](https://help.github.com/en/articles/working-with-forks) this repository, or ensure that your existing fork is up-to-date.
 2. Clone your fork on your local computer, or make sure that your existing clone
 is up-to-date.
 3. Edit your local clone, and commit your changes using `datalad save`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ policy.
 
 The instructions below explain how to find and get data from the dataset.
 You can also add data by following the instructions in our [contribution
-guidelines](https://github.com/CONP-PCNO/conp-dataset/.github/CONTRIBUTING.md).
+guidelines](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md).
 We welcome your feedback! :smiley:
 
 ## Dataset structure


### PR DESCRIPTION
## Description

This PR modifies the contribution guide as follows:
* Added new instructions on how to get a DOI for a dataset, following discussion at the dev meeting today
* Instructions on how to get help, following @kaitj suggestion in #57 
* Moved up instructions on how to use git and github, following @kaitj suggestion in #57 
* Integrated metadata instructions to "Add data" workflow, mentioned the need for a `dats.json` file
* Fixed broken link in `README.md`

## Checklist

Irrelevant here, this is not a new dataset.

Mandatory files and elements:
- [ ] A `README.md` file, at the root of the dataset
- [ ] A `dats.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [ ] `dats.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
#57 
