### PR TITLE
Added auto assign, fixed link in README

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,23 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - jbpoline
+  - paiva
+  - edickie
+  - glatard
+  - dlq
+  - PapillonMcGill
+  - shots47s
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ policy.
 
 The instructions below explain how to find and get data from the dataset.
 You can also add data by following the instructions in our [contribution
-guidelines](https://github.com/CONP-PCNO/conp-dataset/.github/CONTRIBUTING.md).
+guidelines](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md).
 We welcome your feedback! :smiley:
 
 ## Dataset structure


### PR DESCRIPTION
## Description
This adds `auto-assign` to the repo, following this morning's discussion and suggestion by @edickie. This config should auto assign 2 random reviewers to any pull request, chosen in the following list:
  - @jbpoline
  - @paiva
  - @edickie
  - @glatard
  - @dlq
  - @PapillonMcGill
  - @shots47s