### PR TITLE
Add zenodo crawler script (in progress)

### DIFF
--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -1,0 +1,52 @@
+import requests
+import os
+import json
+
+
+def crawl():
+    dats = get_dats()
+    print(dats)
+
+
+def get_dats():
+    dats_list = []
+
+    for dataset in os.listdir("projects"):
+        if dataset[0] == ".":
+            continue
+        dir_list = os.listdir(os.path.join("projects", dataset))
+        dats_name = ""
+        if "dats.json" in dir_list:
+            dats_name = "dats.json"
+        elif "DATS.json" in dir_list:
+            dats_name = "DATS.json"
+        if dats_name is not "":
+            with open(os.path.join("projects", dataset, dats_name), "r") as f:
+                dats_list.append(json.load(f))
+
+    for dataset in os.listdir("investigators"):
+        if dataset[0] == ".":
+            continue
+        dir_list = os.listdir(os.path.join("investigators", dataset))
+        dats_name = ""
+        if "dats.json" in dir_list:
+            dats_name = "dats.json"
+        elif "DATS.json" in dir_list:
+            dats_name = "DATS.json"
+        if dats_name is not "":
+            with open(os.path.join("investigators", dataset, dats_name), "r") as f:
+                dats_list.append(json.load(f))
+
+    return dats_list
+
+
+def get_zenodo_datasets():
+    r = requests.get("https://zenodo.org/api/records/?"
+                     "type=dataset&"
+                     "q=keywords:\"canadian-open-neuroscience-platform\"&"
+                     "size=9999")
+    return r.json()["hits"]["hits"]
+
+
+if __name__ == "__main__":
+    print(len(get_zenodo_datasets()))

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -2,7 +2,6 @@ import requests
 import os
 import json
 import sys
-from zipfile import ZipFile
 import datalad.api as api
 from re import sub
 
@@ -32,11 +31,9 @@ def crawl():
 
 def get_token():
     if len(sys.argv) != 2:
-        raise Exception("Need to pass Github access token")
+        raise Exception("Need to pass only your Github access token")
 
-    token = sys.argv[1]
-
-    return token
+    return sys.argv[1]
 
 
 def get_conp_dois():
@@ -138,26 +135,14 @@ clean = lambda x: sub('\W|^(?=\d)','_', x)
 
 def create_new_dataset(dataset, token):
     dir = os.path.join("projects", dataset["title"])
-    api.create(dir)
-    api.create_sibling_github(("conp-dataset-" + dataset["title"])[0:100],
-                              dataset=dir,
-                              recursive=True,
-                              github_login=token,
-                              github_passwd=token)
+    d = api.Dataset(dir)
+    d.create()
+    d.create_sibling_github(("conp-dataset-" + dataset["title"])[0:100],
+                            github_login=token,
+                            github_passwd=token)
     for file_url in dataset["files"]:
-        # r = requests.get(file_url)
-        # if r.ok:
-        #     with open("temp.zip", "wb") as f:
-        #         f.write(r.content)
-        #     with ZipFile("temp.zip", "r") as f:
-        #         f.extractall(dir)
-        # else:
-        #     raise Exception("Failed to download zip file: " + file_url)
-        print(api.download_url(file_url, path=dir))
-        print(api.save(dir))
-
-
-        # print(api.publish(dataset=dir, to="github"))
+        d.download_url(file_url, archive=True)
+        d.publish(to="github")
 
 
 if __name__ == "__main__":

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -4,11 +4,28 @@ import json
 
 
 def crawl():
-    dats = get_dats()
-    print(dats)
+    zenodo_dois = get_zenodo_dois()
+    conp_dois = get_conp_dois()
+
+    # Verify no duplicates in both lists
+    verify_duplicates(zenodo_dois, conp_dois)
+
+    for dataset in zenodo_dois:
+        index = next((i for (i, d) in enumerate(conp_dois) if d["concept_doi"] == dataset["concept_doi"]), None)
+
+        # If the zenodo dataset exists in conp datasets
+        if index is not None:
+            # If the conp dataset version isn't the lastest, update
+            if dataset["latest_version"] != conp_dois[index]["version"]:
+                # Update
+        else:
+            # Update
 
 
-def get_dats():
+    print(conp_dois)
+
+
+def get_conp_dois():
     dats_list = []
 
     for dataset in os.listdir("projects"):
@@ -21,8 +38,13 @@ def get_dats():
         elif "DATS.json" in dir_list:
             dats_name = "DATS.json"
         if dats_name is not "":
-            with open(os.path.join("projects", dataset, dats_name), "r") as f:
-                dats_list.append(json.load(f))
+            directory = os.path.join("projects", dataset)
+            with open(os.path.join(directory, dats_name), "r") as f:
+                dat = json.load(f)
+                if "zenodo" in dat.keys():
+                    new_dict = dat["zenodo"]
+                    new_dict.update({"directory": directory})
+                    dats_list.append(new_dict)
 
     for dataset in os.listdir("investigators"):
         if dataset[0] == ".":
@@ -34,19 +56,54 @@ def get_dats():
         elif "DATS.json" in dir_list:
             dats_name = "DATS.json"
         if dats_name is not "":
-            with open(os.path.join("investigators", dataset, dats_name), "r") as f:
-                dats_list.append(json.load(f))
+            directory = os.path.join("investigators", dataset)
+            with open(os.path.join(directory, dats_name), "r") as f:
+                dat = json.load(f)
+                if "zenodo" in dat.keys():
+                    new_dict = dat["zenodo"]
+                    new_dict.update({"directory": directory})
+                    dats_list.append(new_dict)
 
     return dats_list
 
 
-def get_zenodo_datasets():
+def get_zenodo_dois():
+    zenodo_dois = []
     r = requests.get("https://zenodo.org/api/records/?"
-                     "type=dataset&"
-                     "q=keywords:\"canadian-open-neuroscience-platform\"&"
-                     "size=9999")
-    return r.json()["hits"]["hits"]
+                     # "type=dataset&"
+                     # "q=keywords:\"canadian-open-neuroscience-platform\"&"
+                     "q=keywords:\"analysis\"&"
+                     "size=20").json()["hits"]["hits"]
+    for dataset in r:
+        concept_doi = dataset["conceptrecid"]
+        if len(dataset["metadata"]["relations"]["version"]) != 1:
+            raise Exception("Unexpected multiple versions")
+        latest_version_doi = dataset["metadata"]["relations"]["version"][0]["last_child"]["pid_value"]
+        zenodo_dois.append({
+            "concept_doi": concept_doi,
+            "latest_version": latest_version_doi
+        })
+
+    return zenodo_dois
+
+
+def verify_duplicates(zenodo_dois, conp_dois):
+    concept_dois = list(map(lambda x: x["concept_doi"], zenodo_dois))
+    if len(concept_dois) != len(set(concept_dois)):
+        raise Exception("Concept DOI duplicates exists in zenodo list")
+    version_dois = list(map(lambda x: x["latest_version"], zenodo_dois))
+    if len(version_dois) != len(set(version_dois)):
+        raise Exception("Version DOI duplicates exists in zenodo list")
+    concept_dois = list(map(lambda x: x["concept_doi"], conp_dois))
+    if len(concept_dois) != len(set(concept_dois)):
+        raise Exception("Concept DOI duplicates exists in conp list")
+    version_dois = list(map(lambda x: x["version"], conp_dois))
+    if len(version_dois) != len(set(version_dois)):
+        raise Exception("Version DOI duplicates exists in conp list")
+    directories = list(map(lambda x: x["directory"], conp_dois))
+    if len(directories) != len(set(directories)):
+        raise Exception("Directory duplicates exists in conp list")
 
 
 if __name__ == "__main__":
-    print(len(get_zenodo_datasets()))
+    crawl()

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -1,9 +1,17 @@
 import requests
 import os
 import json
+import sys
+from zipfile import ZipFile
+import datalad.api as api
+from re import sub
 
 
 def crawl():
+
+    # Get github username and password
+    token = get_token()
+
     zenodo_dois = get_zenodo_dois()
     conp_dois = get_conp_dois()
 
@@ -17,12 +25,18 @@ def crawl():
         if index is not None:
             # If the conp dataset version isn't the lastest, update
             if dataset["latest_version"] != conp_dois[index]["version"]:
-                # Update
+                pass
         else:
-            # Update
+            create_new_dataset(dataset, token)
 
 
-    print(conp_dois)
+def get_token():
+    if len(sys.argv) != 2:
+        raise Exception("Need to pass Github access token")
+
+    token = sys.argv[1]
+
+    return token
 
 
 def get_conp_dois():
@@ -72,16 +86,25 @@ def get_zenodo_dois():
     r = requests.get("https://zenodo.org/api/records/?"
                      # "type=dataset&"
                      # "q=keywords:\"canadian-open-neuroscience-platform\"&"
-                     "q=keywords:\"analysis\"&"
-                     "size=20").json()["hits"]["hits"]
+                     # "q=keywords:\"analysis\"&"
+                     "q=3363060"
+                     "size=1").json()["hits"]["hits"]
     for dataset in r:
         concept_doi = dataset["conceptrecid"]
         if len(dataset["metadata"]["relations"]["version"]) != 1:
             raise Exception("Unexpected multiple versions")
         latest_version_doi = dataset["metadata"]["relations"]["version"][0]["last_child"]["pid_value"]
+        zip_files = []
+        for bucket in dataset["files"]:
+            if bucket["type"] == "zip":
+                zip_files.append(bucket["links"]["self"])
+        if len(zip_files) < 1:
+            print("Zenodo dataset " + dataset["title"] + " does not contain a zip file")
         zenodo_dois.append({
             "concept_doi": concept_doi,
-            "latest_version": latest_version_doi
+            "latest_version": latest_version_doi,
+            "title": clean(dataset["metadata"]["title"]),
+            "files": zip_files
         })
 
     return zenodo_dois
@@ -94,6 +117,12 @@ def verify_duplicates(zenodo_dois, conp_dois):
     version_dois = list(map(lambda x: x["latest_version"], zenodo_dois))
     if len(version_dois) != len(set(version_dois)):
         raise Exception("Version DOI duplicates exists in zenodo list")
+    titles = list(map(lambda x: x["title"], zenodo_dois))
+    if len(titles) != len(set(titles)):
+        raise Exception("Title duplicates exists in zenodo list")
+    file_link = list(map(lambda x: x["file"], zenodo_dois))
+    if len(file_link) != len(set(file_link)):
+        raise Exception("File link duplicates exists in zenodo list")
     concept_dois = list(map(lambda x: x["concept_doi"], conp_dois))
     if len(concept_dois) != len(set(concept_dois)):
         raise Exception("Concept DOI duplicates exists in conp list")
@@ -103,6 +132,28 @@ def verify_duplicates(zenodo_dois, conp_dois):
     directories = list(map(lambda x: x["directory"], conp_dois))
     if len(directories) != len(set(directories)):
         raise Exception("Directory duplicates exists in conp list")
+
+
+clean = lambda x: sub('\W|^(?=\d)','_', x)
+
+
+def create_new_dataset(dataset, token):
+    dir = os.path.join("projects", dataset["title"])
+    api.create(dir)
+    api.create_sibling_github("conp-dataset-" + dataset["title"],
+                              dataset=dir,
+                              recursive=True,
+                              github_login=token,
+                              github_passwd=token)
+    for file_url in dataset["files"]:
+        r = requests.get(file_url)
+        if r.ok:
+            with open("temp.zip", "wb") as f:
+                f.write(r.content)
+            with ZipFile("temp.zip", "r") as f:
+                f.extractall(dir)
+        else:
+            raise Exception("Failed to download zip file: " + file_url)
 
 
 if __name__ == "__main__":

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -139,11 +139,11 @@ clean = lambda x: sub('\W|^(?=\d)','_', x)
 def create_new_dataset(dataset, token):
     dir = os.path.join("projects", dataset["title"])
     api.create(dir)
-    # api.create_sibling_github(("conp-dataset-" + dataset["title"])[0:100],
-    #                           dataset=dir,
-    #                           recursive=True,
-    #                           github_login=token,
-    #                           github_passwd=token)
+    api.create_sibling_github(("conp-dataset-" + dataset["title"])[0:100],
+                              dataset=dir,
+                              recursive=True,
+                              github_login=token,
+                              github_passwd=token)
     for file_url in dataset["files"]:
         # r = requests.get(file_url)
         # if r.ok:
@@ -153,7 +153,10 @@ def create_new_dataset(dataset, token):
         #         f.extractall(dir)
         # else:
         #     raise Exception("Failed to download zip file: " + file_url)
-        api.download_url(file_url, path=dir, archive=True)
+        print(api.download_url(file_url, path=dir))
+        print(api.save(dir))
+
+
         # print(api.publish(dataset=dir, to="github"))
 
 


### PR DESCRIPTION
## Description
Instead of going through the complex procedure of uploading a dataset themselves, the dataset owners can now upload their dataset onto Zenodo with the keyword `canadian-open-neuroscience-platform` and this script will automatically fetch new changes and versions and create a pull request to this repository.

The procedure is as follows:
1. Make sure you have an up to date repository by pulling
2. Retrieve all current conp-dataset information stored in dats.json files (concept_doi and version_doi)
3. Retrieve all metadata for all zenodo datasets containing the keyword `canadian-open-neuroscience-platform`
4. Looping through the retrieved zenodo datasets metadata:
    1. If zenodo dataset is existing in a conp-dataset by comparing concept_doi:
        1. If the conp-dataset version is not current by comparing the zenodo dataset latest_version_doi with the conp-dataset version_doi:
            1. Update conp-dataset
    2. If the zenodo dataset doesn't exist in conp-dataset by seeing that the zenodo concept_doi is not in the concept_dois retrieved from conp-datasets
        1. Download zenodo dataset into a new dataset/directory
5. Create pull requests with changes

Here is some documentation regarding [concept_dois](http://help.zenodo.org/#versioning)

Issue #79 