### PR TITLE
Adding FRDR dataset to CONP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "projects/refseq"]
   path = projects/refseq
   url = https://github.com/emmetaobrien/refseq.git
+[submodule "projects/FRDR-multimodal"]
+	path = projects/FRDR-multimodal
+	url = ./projects/FRDR-multimodal

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,5 +35,5 @@
   path = projects/refseq
   url = https://github.com/emmetaobrien/refseq.git
 [submodule "projects/FRDR-multimodal"]
-	path = projects/FRDR-multimodal
-	url = ./projects/FRDR-multimodal
+  path = projects/FRDR-multimodal
+  url = https://github.com/gi114/FRDR-multimodal


### PR DESCRIPTION
## Description
PR to add the FRDR Multimodal dataset to CONP

A README and dats file are present at the dataset root

### Test
Run:
```
datalad install -r http://github.com/gi114/conp-dataset/FRDR-multimodal
cd conp-dataset/projects/FRDR-multimodal
```
You should be able to access the dataset content

Mandatory files and elements:
- [ ] A `README.md` file, at the root of the dataset
- [ ] A `dats.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [ ] `dats.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset

