### PR TITLE
[Test function] Timeout download and hanging authentication

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -55,17 +55,13 @@ def recurse(directory, odds):
 
         # If the file is a broken symlink and with odd chance
         elif not exists(full_path) and random() < odds:
-            try:
-                # Timeouts the download or a hanging authentification
-                with timeout(3): 
-                    msg = api.get(path=full_path, on_failure="ignore", return_type="item-or-list")
-                    
-                    # Check for authentication
-                    if msg["status"] == "error" and "unable to access" not in msg["message"].lower():
-                        return "Cannot download file and didn't hit authentication request for file: " + full_path
-
-            except TimeoutError:
-                pass 
+            # Timeouts the download or a hanging authentification
+            with timeout(3): 
+                msg = api.get(path=full_path, on_failure="ignore", return_type="item-or-list")
+                
+                # Check for authentication
+                if msg["status"] == "error" and "unable to access" not in msg["message"].lower():
+                    return "Cannot download file and didn't hit authentication request for file: " + full_path
 
     return "All good"
 

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -1,7 +1,31 @@
+from contextlib import contextmanager
 from os import listdir, walk
 from os.path import isdir, exists, join, abspath, basename, dirname
 from random import random
+import signal
+
 import datalad.api as api
+
+
+@contextmanager
+def timeout(time):
+    # Register a function to raise a TimeoutError on the signal.
+    signal.signal(signal.SIGALRM, raise_timeout)
+    # Schedule the signal to be sent after ``time``.
+    signal.alarm(time)
+
+    try:
+        yield
+    except TimeoutError:
+        pass
+    finally:
+        # Unregister the signal so it won't be triggered
+        # if the timeout is not reached.
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)
+
+
+def raise_timeout(signum, frame):
+    raise TimeoutError
 
 
 def recurse(directory, odds):
@@ -31,11 +55,17 @@ def recurse(directory, odds):
 
         # If the file is a broken symlink and with odd chance
         elif not exists(full_path) and random() < odds:
-            msg = api.get(path=full_path, on_failure="ignore", return_type="item-or-list")
+            try:
+                # Timeouts the download or a hanging authentification
+                with timeout(3): 
+                    msg = api.get(path=full_path, on_failure="ignore", return_type="item-or-list")
+                    
+                    # Check for authentication
+                    if msg["status"] == "error" and "unable to access" not in msg["message"].lower():
+                        return "Cannot download file and didn't hit authentication request for file: " + full_path
 
-            # Check for authentication
-            if msg["status"] == "error" and "unable to access" not in msg["message"].lower():
-                return "Cannot download file and didn't hit authentication request for file: " + full_path
+            except TimeoutError:
+                pass 
 
     return "All good"
 


### PR DESCRIPTION
## Description
Currently, some dataset tests are failing due to hanging authentication.
I think that timing out the request should solve that issue.

The timeout prevents two things: (1) hanging prompt for authentication and (2) full download of the data. (1) Prevent tests to fail when credentials are not provided while (2) aims at improving speed.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
This PR should solve the authentication hanging issue with PR #82, #84, #86.
