### PR TITLE
Make tests check submodules, not directories

### DIFF
--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -1,17 +1,18 @@
-from os import listdir
 from string import Template
+from git import Repo
 
 
-dataset_titles = list(filter(lambda x: x[0] != ".", listdir("projects") + listdir("investigators")))
+submodules = list(map(lambda x: x.name, Repo(".").submodules))
 
 template = Template("""from functions import examine
 
 
-def test_$title_no_hyphen():
-    assert examine('$title') == 'All good'
+def test_$clean_title():
+    assert examine('$path') == 'All good'
 """)
 
-for title in dataset_titles:
-    with open("tests/test_" + title + ".py", "w") as f:
+for dataset in submodules:
+    with open("tests/test_" + dataset.replace("/", "_") + ".py", "w") as f:
 
-        f.write(template.substitute(title=title, title_no_hyphen=title.replace("-", "_")))
+        f.write(template.substitute(path=dataset,
+                                    clean_title=dataset.replace("/", "_").replace("-", "_")))

--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -2,7 +2,7 @@ from string import Template
 from git import Repo
 
 
-submodules = list(map(lambda x: x.name, Repo(".").submodules))
+submodules = list(map(lambda x: x.path, Repo(".").submodules))
 
 template = Template("""from functions import examine
 

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -70,8 +70,8 @@ def examine(dataset):
 
     # Check if dats.json and README.md are present in root of dataset
     file_names = [file_name for file_name in listdir(dataset)]
-    if "dats.json" not in file_names:
-        return "Dataset " + dataset + " doesn't contain dats.json in its root directory"
+    if "DATS.json" not in file_names:
+        return "Dataset " + dataset + " doesn't contain DATS.json in its root directory"
 
     if "README.md" not in file_names:
         return "Dataset " + dataset + " doesn't contain README.md in its root directory"

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -69,11 +69,11 @@ def recurse(directory, odds):
 def examine(dataset):
 
     # Check if dats.json and README.md are present in root of dataset
-    file_names = [file_name.lower() for file_name in listdir(dataset)]
+    file_names = [file_name for file_name in listdir(dataset)]
     if "dats.json" not in file_names:
         return "Dataset " + dataset + " doesn't contain dats.json in its root directory"
 
-    if "readme.md" not in file_names:
+    if "README.md" not in file_names:
         return "Dataset " + dataset + " doesn't contain README.md in its root directory"
 
     # Number of files to test in each dataset

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -68,27 +68,23 @@ def recurse(directory, odds):
 
 def examine(dataset):
 
-    # Root directory can be projects or investigators
-    root_dir = "projects" if dataset in listdir("projects") else "investigators"
-    full_dir = join(root_dir, dataset)
-
     # Check if dats.json and README.md are present in root of dataset
-    file_names = [file_name.lower() for file_name in listdir(full_dir)]
+    file_names = [file_name.lower() for file_name in listdir(dataset)]
     if "dats.json" not in file_names:
-        return "Dataset " + full_dir + " doesn't contain dats.json in its root directory"
+        return "Dataset " + dataset + " doesn't contain dats.json in its root directory"
 
     if "readme.md" not in file_names:
-        return "Dataset " + full_dir + " doesn't contain README.md in its root directory"
+        return "Dataset " + dataset + " doesn't contain README.md in its root directory"
 
     # Number of files to test in each dataset
     # with 100 files, the test is not completing before Travis timeout (about 10~12 minutes)
     num_files = 4
     
     # Count the number of testable files while ignoring files in directories starting with "."
-    count = sum([len(files) if basename(dirname(r))[0] != "." else 0 for r, d, files in walk(full_dir)])
+    count = sum([len(files) if basename(dirname(r))[0] != "." else 0 for r, d, files in walk(dataset)])
 
     # Calculate the odds to test a file
     odds = num_files/count
 
     # Start to test dataset
-    return recurse(abspath(full_dir), odds)
+    return recurse(abspath(dataset), odds)


### PR DESCRIPTION
## Description
Instead of assuming every directory under "projects" or "investigators" is a dataset, get dataset paths from submodules.path instead from the .gitmodules file. Update tests to reflect the changes.
IMPORTANT: making tests enforce specifically "DATS.json" and "README.md" as written!!!!

## Related issues (optional)
#92 
