### PR TITLE
Make Travis.CI only test submodules that differ (not ready, please do not merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 tests/test*
 __pycache__/
 .DS_Store
+tests/diff.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ python:
 
 git:
   submodules: false
+  depth: 1
 
 before_install:
+- git clone --depth=1 --branch=master https://github.com/CONP-PCNO/conp-dataset.git ../conp-dataset-master
 - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
 - sudo apt-get -q install -y git-annex-standalone
 
@@ -16,8 +18,12 @@ install:
 - pip install datalad
 - pip freeze
 - datalad install -r .
+- datalad install -r ../conp-dataset-master
+- git config --global diff.renames 0
+- git diff --no-index --name-only . ../conp-dataset-master > tests/diff.txt || true
+- sed -i '\?^/dev/null?d' ./tests/diff.txt
 
 script:
 - find . -name config.sh | xargs bash
 - python tests/create_tests.py
-- pytest tests/
+- PYTHONPATH=$PWD pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,24 +6,36 @@ python:
 - 3.6
 
 git:
+  # Skip automatic submodule cloning, since we are going to use datalad install instead
   submodules: false
+  # Shallow clone
   depth: 1
 
 before_install:
+# Shallow clone diff target
 - git clone --depth=1 --branch=master https://github.com/CONP-PCNO/conp-dataset.git ../conp-dataset-master
+# Install git annex, dependency for datalad
 - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
 - sudo apt-get -q install -y git-annex-standalone
 
 install:
+# Install datalad and install content of submodules
 - pip install datalad
 - pip freeze
 - datalad install -r .
 - datalad install -r ../conp-dataset-master
-- git config --global diff.renames 0
-- git diff --no-index --name-only . ../conp-dataset-master > tests/diff.txt || true
-- sed -i '\?^/dev/null?d' ./tests/diff.txt
 
 script:
+# Turn off file rename checking when doing a git diff
+- git config --global diff.renames 0
+# git diff between the incoming branch and the master branch of CONP-PCNO/conp-dataset
+# and pipe the output to tests/diff.txt
+# Note: I wasn't able to find a way to do a git diff between two directories with gitpython,
+# but if it is possible, please implement it in tests/create_tests.py and remove
+# the previous and the next two commands from travis.yml
+- git diff --no-index --name-only . ../conp-dataset-master > tests/diff.txt || true
+# Clean diff.txt from useless lines
+- sed -i '\?^/dev/null?d' ./tests/diff.txt
 - find . -name config.sh | xargs bash
 - python tests/create_tests.py
 - PYTHONPATH=$PWD pytest tests/

--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -1,6 +1,6 @@
 from string import Template
 from git import Repo
-from os.path import isfile
+from os.path import isfile, join
 
 
 submodules = list(map(lambda x: x.path, Repo(".").submodules))
@@ -10,16 +10,9 @@ if isfile("tests/diff.txt"):
     with open("tests/diff.txt", "r") as f:
         changes = f.readlines()
 
-    for line in changes:
-        for submodule in submodules:
-            if submodule in line:
-                changed_submodules.add(submodule)
+    changed_submodules = {submodule for submodule in submodules for line in changes if submodule in line}
 
-    if len(changed_submodules) > 0:
-        print("Detected changes in the following submodules, creating tests for them:")
-        for submodule in changed_submodules:
-            print(submodule)
-    else:
+    if len(changed_submodules) == 0:
         print("No changes in submodules")
 else:
     print("No diff.txt file detected, creating tests for every submodule")
@@ -34,7 +27,9 @@ def test_$clean_title():
 """)
 
 for submodule in changed_submodules:
-    with open("tests/test_" + submodule.replace("/", "_") + ".py", "w") as f:
+    test_file = "test_" + submodule.replace("/", "_") + ".py"
+    print("Creating " + test_file)
+    with open(join("tests", test_file), "w") as f:
 
         f.write(template.substitute(path=submodule,
                                     clean_title=submodule.replace("/", "_").replace("-", "_")))

--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -4,6 +4,23 @@ from git import Repo
 
 submodules = list(map(lambda x: x.path, Repo(".").submodules))
 
+with open("tests/diff.txt", "r") as f:
+    changes = f.readlines()
+
+changed_submodules = set()
+for line in changes:
+    for submodule in submodules:
+        if submodule in line:
+            changed_submodules.add(submodule)
+
+if len(changed_submodules) > 0:
+    print("Detected changes in the following submodules:")
+    for submodule in changed_submodules:
+        print(submodule)
+else:
+    print("No changes in submodules")
+
+
 template = Template("""from functions import examine
 
 
@@ -11,8 +28,8 @@ def test_$clean_title():
     assert examine('$path') == 'All good'
 """)
 
-for dataset in submodules:
-    with open("tests/test_" + dataset.replace("/", "_") + ".py", "w") as f:
+for submodule in changed_submodules:
+    with open("tests/test_" + submodule.replace("/", "_") + ".py", "w") as f:
 
-        f.write(template.substitute(path=dataset,
-                                    clean_title=dataset.replace("/", "_").replace("-", "_")))
+        f.write(template.substitute(path=submodule,
+                                    clean_title=submodule.replace("/", "_").replace("-", "_")))

--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -1,24 +1,29 @@
 from string import Template
 from git import Repo
+from os.path import isfile
 
 
 submodules = list(map(lambda x: x.path, Repo(".").submodules))
-
-with open("tests/diff.txt", "r") as f:
-    changes = f.readlines()
-
 changed_submodules = set()
-for line in changes:
-    for submodule in submodules:
-        if submodule in line:
-            changed_submodules.add(submodule)
 
-if len(changed_submodules) > 0:
-    print("Detected changes in the following submodules:")
-    for submodule in changed_submodules:
-        print(submodule)
+if isfile("tests/diff.txt"):
+    with open("tests/diff.txt", "r") as f:
+        changes = f.readlines()
+
+    for line in changes:
+        for submodule in submodules:
+            if submodule in line:
+                changed_submodules.add(submodule)
+
+    if len(changed_submodules) > 0:
+        print("Detected changes in the following submodules, creating tests for them:")
+        for submodule in changed_submodules:
+            print(submodule)
+    else:
+        print("No changes in submodules")
 else:
-    print("No changes in submodules")
+    print("No diff.txt file detected, creating tests for every submodule")
+    changed_submodules = set(submodules)
 
 
 template = Template("""from functions import examine


### PR DESCRIPTION
## Description
Current dataset testing procedure is unscalable, as it tests every single existing dataset present in repository, see related issue. Proposed solution is to test datasets/submodules that have changes from the incoming branch vs CONP-PCNO/conp-dataset:master in the PR:
1) Make a shallow clone of the master branch
2) Make a git diff with the incoming PR
3) From the diff, identify the datasets that are touched by the PR
4) For each touched dataset, run the tests

Detailed procedure is:
1) Shallow clone incoming PR branch
2) Shallow clone CONP-PCNO/conp-dataset:master in another directory
3) Install dependencies
4) `datalad install -r` both repositories
5) `git diff --name-only` both repositories and pipe file names output to `tests/diff.txt`
6) Clean `diff.txt` from numerous lines of `dev/null`
7) `tests/create_tests.py` now checks for existence of `diff.txt` and if it exists, it will create tests only for the submodules that have changes by reading and comparing from `diff.txt`
8) If `diff.txt` does not exist, for example when the user want to test their dataset locally, `tests/create_tests.py` creates tests for every single submodule so that the user can choose which ones to run
9) Run all tests

## Related issues (optional)
#89 
