### PR TITLE
fix zenodo crawler tests failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 install:
 - pip install datalad
 - pip freeze
-- datalad install -r .
+- datalad install -r . || true
 
 script:
 - find . -name config.sh | xargs bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 install:
 - pip install datalad
 - pip freeze
-- datalad install -r . || true
+- datalad install -r .
 
 script:
 - find . -name config.sh | xargs bash

--- a/tests/test_zenodo_crawler.py
+++ b/tests/test_zenodo_crawler.py
@@ -50,6 +50,7 @@ def mock_get_test_dataset_dir():
 
 class TestZenodoCrawler(TestCase):
 
+    @mock.patch("scripts.crawl_zenodo.check_requirements", return_value="username")
     @mock.patch("scripts.crawl_zenodo.commit_push_file")
     @mock.patch("scripts.crawl_zenodo.store")
     @mock.patch("scripts.crawl_zenodo.parse_args", return_value=mock_input())
@@ -66,12 +67,13 @@ class TestZenodoCrawler(TestCase):
     def test_create_new_dataset(self, mock_datalad_add, mock_dataset, mock_repo, mock_verify_repo,
                                 mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                 mock_create_new_dats, mock_empty_conp_dois, mock_zenodo_query, mock_input,
-                                mock_store, mock_commit_push_file):
+                                mock_store, mock_commit_push_file, mock_check_requirements):
         try:
             crawl()
         except Exception as e:
             self.fail("Unexpected Exception raised: " + str(e))
 
+    @mock.patch("scripts.crawl_zenodo.check_requirements", return_value="username")
     @mock.patch("scripts.crawl_zenodo.commit_push_file")
     @mock.patch("scripts.crawl_zenodo.store")
     @mock.patch("scripts.crawl_zenodo.parse_args", return_value=mock_input())
@@ -88,7 +90,7 @@ class TestZenodoCrawler(TestCase):
     def test_update_existing_dataset(self, mock_datalad_add, mock_dataset, mock_repo, mock_verify_repo,
                                      mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                      mock_create_new_dats, mock_get_test_dataset_dir, mock_zenodo_query,
-                                     mock_input, mock_store, mock_commit_push_file):
+                                     mock_input, mock_store, mock_commit_push_file, mock_check_requirements):
         try:
             crawl()
         except Exception as e:


### PR DESCRIPTION
## Description
Fix zenodo crawler tests failing

Added `|| true` to `datalad install -r .` because installing Park-Patrick dataset causes that command and the entire travis build to crash:
![image](https://user-images.githubusercontent.com/35869923/69775898-4cbdce80-1168-11ea-9347-6d6426d1aa78.png)

Possible alternative: 
- Remove Park-Patrick dataset
