### PR TITLE
Adding CONP_status to DATS.json

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,12 +7,13 @@ addAssignees: true
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers: 
   - jbpoline
-  - paiva
   - edickie
   - glatard
   - dlq
   - PapillonMcGill
-  - shots47s
+  - emmetaobrien
+  - xlecours
+
 
 # A list of keywords to be skipped the process that add reviewers if pull requests include it 
 skipKeywords:

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 venv/
 tests/test*
 !tests/test_zenodo_crawler.py
+!tests/test_dats_validator.py
 __pycache__/
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "projects/PERFORM_Dataset__one_control_subject"]
   path = projects/PERFORM_Dataset__one_control_subject
   url = https://github.com/conp-bot/conp-dataset-PERFORM_Dataset__one_control_subject.git
+[submodule "projects/phantom-test"]
+	path = projects/phantom-test
+	url = ./projects/phantom-test

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,16 +15,16 @@
   url = https://github.com/khanlab-datasets/HCPUR100-Template.git
 [submodule "projects/1000GenomesProject"]
   path = projects/1000GenomesProject
-  url = https://github.com/emmetaobrien/1000GenomesProject.git
+  url = https://github.com/conpdatasets/1000GenomesProject.git
 [submodule "projects/refseq"]
   path = projects/refseq
-  url = https://github.com/emmetaobrien/refseq.git
+  url = https://github.com/conpdatasets/refseq.git
 [submodule "projects/Brainspan"]
   path = projects/Brainspan
-  url = https://github.com/emmetaobrien/Brainspan.git
+  url = https://github.com/conpdatasets/Brainspan.git
 [submodule "projects/nhpatlas"]
   path = projects/nhpatlas
-  url = https://github.com/emmetaobrien/nhpatlas.git
+  url = https://github.com/conpdatasets/nhpatlas.git
 [submodule "investigators/Khanlab/BigBrainMRICoreg"]
   path = investigators/Khanlab/BigBrainMRICoreg
   url = https://github.com/khanlab-datasets/BigBrainMRICoreg
@@ -33,10 +33,10 @@
   url = https://github.com/khanlab-datasets/BigBrainHippoUnfold
 [submodule "projects/mm_neo_atlas"]
   path = projects/mm_neo_atlas
-  url = https://github.com/emmetaobrien/mm_neo_atlas.git
+  url = https://github.com/conpdatasets/mm_neo_atlas.git
 [submodule "projects/celltypes"]
   path = projects/celltypes
-  url = https://github.com/emmetaobrien/celltypes.git
+  url = https://github.com/conpdatasets/celltypes.git
 [submodule "openpain-thermal"]
 	path = projects/openpain/thermal
 	url = https://github.com/big-data-lab-team/openpain-thermal.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -60,4 +60,4 @@
 	url = https://github.com/big-data-lab-team/openpain-BrainNetworkChange_Mano.git
 [submodule "projects/preventad-test"]
 	path = projects/preventad-test
-	url = ./projects/preventad-test
+	url = https://github.com/emmetaobrien/preventad-test.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 [submodule "projects/celltypes"]
   path = projects/celltypes
   url = https://github.com/emmetaobrien/celltypes.git
-[submodule "projects/PERFORM_Dataset__one_control_subject"]
-  path = projects/PERFORM_Dataset__one_control_subject
-  url = https://github.com/conp-bot/conp-dataset-PERFORM_Dataset__one_control_subject.git
 [submodule "openpain-thermal"]
 	path = projects/openpain/thermal
 	url = https://github.com/big-data-lab-team/openpain-thermal.git
@@ -58,6 +55,6 @@
 [submodule "openpain-BrainNetworkChange_Mano"]
 	path = projects/openpain/BrainNetworkChange_Mano
 	url = https://github.com/big-data-lab-team/openpain-BrainNetworkChange_Mano.git
-[submodule "projects/preventad-test"]
-	path = projects/preventad-test
-	url = https://github.com/emmetaobrien/preventad-test.git
+[submodule "projects/PERFORM_Dataset__one_control_subject"]
+  path = projects/PERFORM_Dataset__one_control_subject
+  url = https://github.com/conp-bot/conp-dataset-PERFORM_Dataset__one_control_subject.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -58,6 +58,6 @@
 [submodule "projects/PERFORM_Dataset__one_control_subject"]
   path = projects/PERFORM_Dataset__one_control_subject
   url = https://github.com/conp-bot/conp-dataset-PERFORM_Dataset__one_control_subject.git
-[submodule "projects/phantom-test"]
-	path = projects/phantom-test
-	url = ./projects/phantom-test
+[submodule "scripts/dats_validator/conp-dats"]
+	path = scripts/dats_validator/conp-dats
+	url = https://github.com/CONP-PCNO/schema

--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "openpain-BrainNetworkChange_Mano"]
 	path = projects/openpain/BrainNetworkChange_Mano
 	url = https://github.com/big-data-lab-team/openpain-BrainNetworkChange_Mano.git
+[submodule "projects/preventad-test"]
+	path = projects/preventad-test
+	url = ./projects/preventad-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 
 install:
 - pip install datalad
+- pip install -r scripts/dats_validator/requirements.txt
 - pip freeze
 - datalad install -r .
 

--- a/scripts/dats_validator/README.md
+++ b/scripts/dats_validator/README.md
@@ -1,0 +1,9 @@
+# Simple dats validator
+
+**Usage:**
+<pre>python validator.py --file=doc.json</pre>
+
+**Test valid and invalid examples:**
+
+- valid and invalid dats files are in examples directory
+- tests located in tests/

--- a/scripts/dats_validator/examples/invalid_dats.json
+++ b/scripts/dats_validator/examples/invalid_dats.json
@@ -1,0 +1,1443 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "BY-NC-SA"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"title": "1000 Genomes Project",
+	"description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
+	"storedIn": {
+		"name" : "European Bioinformatics Institute"
+	},
+	"primaryPublications" : [
+		{
+			"title": "A global reference for human genetic variation",
+			"dates": [
+				{
+					"type": {
+						"value":"Primary reference publication date"
+					},
+					"date": "2015-10-01 00:00:00"
+				}
+			],
+			"authors": [
+				{
+				"name":"1000 Genomes Project"
+				}
+			]
+		}
+	],
+	"isAbout": [
+		{
+			"identifier": {
+				"identifier": "9606",
+				"identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/9606"
+			},
+			"name":"Homo sapiens"
+		}
+	],
+	"dates": [
+		{
+			"type": {
+				"value":"CONP DATS JSON fileset creation date"
+			},
+			"date": "2019-06-17 13:16:33"
+		}
+	],
+	"hasPart": [
+		{
+			"test":"Chromosome 1",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"6056764"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"235061"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 10",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3769238"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"144656"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 11",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3793612"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"143588"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 12",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3629625"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"146902"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 13",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2705190"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"113204"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 14",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2490590"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"99773"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 15",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2273944"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"89809"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 16",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2528069"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"84171"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 17",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2143622"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"87646"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 18",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2151346"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"82396"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 19",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1648250"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"67728"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 2",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"6689892"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"254832"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 20",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1702558"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"62847"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 21",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1037591"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"43733"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 22",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1019265"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"40550"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 3",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"5510472"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"213759"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 4",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"5430270"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"217157"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 5",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4978871"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"196285"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 6",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4732160"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"193158"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 7",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4450904"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"170788"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 8",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4368964"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"151538"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 9",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3355633"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"124138"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Mitochondrial genome",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-10-02 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3587"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"20"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": ""
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome X",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3191768"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"210679"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome Y",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"60505"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"1314"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "contact",
+			"values": [
+				{
+					"value": "Jennifer Tremblay-Mercier, Research Co-ordinator, jennifer.tremblay-mercier@douglas.mcgill.ca, 514-761-6131 #3329"
+				}
+			]
+		}
+	]
+}

--- a/scripts/dats_validator/examples/valid_dats.json
+++ b/scripts/dats_validator/examples/valid_dats.json
@@ -1,0 +1,1451 @@
+{
+	"version": "1.0",
+	"privacy": "public open",
+	"licenses": [
+		{
+			"name": "BY-NC-SA"
+		}
+	],
+	"creators": [
+		{
+			"name": "1000 Genomes Project"
+		}
+	],
+	"types": [
+		{
+			"information": {
+				"value": "genomics"
+			}
+		}
+	],
+	"title": "1000 Genomes Project",
+	"description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
+	"storedIn": {
+		"name" : "European Bioinformatics Institute"
+	},
+	"primaryPublications" : [
+		{
+			"identifier": {
+				"identifier": "https://doi.org/10.1038/nature15393"
+			},
+			"title": "A global reference for human genetic variation",
+			"dates": [
+				{
+					"type": {
+						"value":"Primary reference publication date"
+					},
+					"date": "2015-10-01 00:00:00"
+				}
+			],
+			"authors": [
+				{
+				"name":"1000 Genomes Project"
+				}
+			]
+		}
+	],
+	"isAbout": [
+		{
+			"identifier": {
+				"identifier": "9606",
+				"identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/9606"
+			},
+			"name":"Homo sapiens"
+		}
+	],
+	"dates": [
+		{
+			"type": {
+				"value":"CONP DATS JSON fileset creation date"
+			},
+			"date": "2019-06-17 13:16:33"
+		}
+	],
+	"hasPart": [
+		{
+			"title":"Chromosome 1",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"6056764"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"235061"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 10",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3769238"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"144656"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 11",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3793612"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"143588"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 12",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3629625"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"146902"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 13",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2705190"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"113204"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 14",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2490590"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"99773"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 15",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2273944"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"89809"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 16",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2528069"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"84171"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 17",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2143622"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"87646"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 18",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"2151346"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"82396"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 19",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1648250"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"67728"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 2",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"6689892"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"254832"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 20",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1702558"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"62847"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 21",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1037591"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"43733"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 22",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"1019265"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"40550"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 3",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"5510472"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"213759"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 4",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"5430270"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"217157"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 5",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4978871"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"196285"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 6",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4732160"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"193158"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 7",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4450904"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"170788"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 8",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"4368964"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"151538"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome 9",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3355633"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"124138"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Mitochondrial genome",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-10-02 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3587"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"20"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": ""
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome X",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"3191768"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"210679"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title":"Chromosome Y",
+			"creators": [
+				{
+					"name": "1000 Genomes Project"
+				}
+			],
+			"types": [
+				{
+					"information": {
+						"value": "genomics"
+					}
+				}
+			],
+			"dates": [
+				{
+					"type": {
+						"value":"source .vcf file creation date"
+					},
+					"date": "2015-02-18 00:00:00"
+				}
+			],
+			"storedIn": {
+				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
+				"description": "Gzipped .vcf file containing sequence variations"
+			},
+			"dimensions": [
+				{
+					"name": {
+						"value": "Count of Single Nucleotide Polymorphism variants"
+					},
+					"values": [
+						"60505"
+					]
+				},
+				{
+					"name": {
+						"value": "Count of single-nucleotide insertion and deletion events"
+					},
+					"values": [
+						"1314"
+					]
+				}
+			],
+			"extraProperties": [
+				{
+					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+					"values": [
+						{
+							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+						}
+					]
+				}
+			]
+		}
+	],
+	"extraProperties": [
+		{
+			"category": "contact",
+			"values": [
+				{
+					"value": "Jennifer Tremblay-Mercier, Research Co-ordinator, jennifer.tremblay-mercier@douglas.mcgill.ca, 514-761-6131 #3329"
+				}
+			]
+		}
+	]
+}

--- a/scripts/dats_validator/requirements.txt
+++ b/scripts/dats_validator/requirements.txt
@@ -1,0 +1,9 @@
+attrs==19.3.0
+certifi==2019.11.28
+importlib-metadata==1.3.0
+jsonschema==3.2.0
+more-itertools==8.0.2
+pyrsistent==0.15.7
+six==1.13.0
+wincertstore==0.2
+zipp==0.6.0

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -1,0 +1,58 @@
+import jsonschema
+import os
+import json
+import logging
+import getopt
+from sys import argv
+
+
+logger = logging.getLogger(__name__)
+# path to a top-level schema
+SCHEMA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'conp-dats', 'dataset_schema.json')
+
+
+def main(argv):
+    FORMAT = '%(message)s'
+    logging.basicConfig(format=FORMAT)
+    logging.getLogger().setLevel(logging.INFO)
+    opts, args = getopt.getopt(argv, "", ["file="])
+    json_filename = ''
+
+    for opt, arg in opts:
+        if opt == '--file':
+            json_filename = arg
+
+    if json_filename == '':
+        help()
+        exit()
+
+    with open(json_filename) as json_file:
+        json_obj = json.load(json_file)
+        validate_json(json_obj)
+
+
+def validate_json(json_obj):
+    with open(SCHEMA_PATH) as s:
+        json_schema = json.load(s)
+    # first validate schema file
+    v = jsonschema.Draft4Validator(json_schema)
+    # now validate json file
+    try:
+        jsonschema.validate(json_obj, json_schema, format_checker=jsonschema.FormatChecker())
+        logger.info('The file is valid. Validation passed.')
+        return True
+    except jsonschema.exceptions.ValidationError:
+        errors = [e for e in v.iter_errors((json_obj))]
+        logger.info(f"The file is not valid. Total errors: {len(errors)}")
+        for i, error in enumerate(errors, 1):
+            logger.error(f"{i} Validation error in {'.'.join(str(v) for v in error.path)}: {error.message}")
+        logger.info('Validation failed.')
+        return False
+
+
+def help():
+    return logger.info('Usage: python validator.py --file=doc.json')
+
+
+if __name__ == "__main__":
+    main(argv[1:])

--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -12,7 +12,8 @@ def test_$clean_title():
 """)
 
 for dataset in submodules:
-    with open("tests/test_" + dataset.replace("/", "_") + ".py", "w") as f:
+    if dataset.split("/")[0] == "projects" or dataset.split("/")[0] == "investigators":
+        with open("tests/test_" + dataset.replace("/", "_") + ".py", "w") as f:
 
-        f.write(template.substitute(path=dataset,
-                                    clean_title=dataset.replace("/", "_").replace("-", "_")))
+            f.write(template.substitute(path=dataset,
+                                        clean_title=dataset.replace("/", "_").replace("-", "_")))

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -60,7 +60,7 @@ def recurse(directory, odds):
                 msg = api.get(path=full_path, on_failure="ignore", return_type="item-or-list")
                 
                 # Check for authentication
-                if msg["status"] == "error" and "unable to access" not in msg["message"].lower():
+                if isinstance(msg, dict) and msg["status"] == "error" and "unable to access" not in msg["message"].lower():
                     return "Cannot download file and didn't hit authentication request for file: " + full_path
 
     return "All good"

--- a/tests/test_dats_validator.py
+++ b/tests/test_dats_validator.py
@@ -1,0 +1,27 @@
+import unittest
+import json
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'scripts'))
+from dats_validator.validator import validate_json
+
+
+EXAMPLES = os.path.join(os.path.dirname(sys.path[0]), 'scripts', 'dats_validator', 'examples')
+
+class JsonschemaTest(unittest.TestCase):
+    valid =  os.path.join(EXAMPLES, 'valid_dats.json')
+    invalid = os.path.join(EXAMPLES, 'invalid_dats.json')
+
+    def test_validate_json(self):
+        with open(self.valid) as v_file:
+            valid_obj = json.load(v_file)
+            valid_validation = validate_json(valid_obj)
+        with open(self.invalid) as inv_file:
+            invalid_obj = json.load(inv_file)
+            invalid_validation = validate_json(invalid_obj)
+        self.assertEqual(valid_validation, True)
+        self.assertEqual(invalid_validation, False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds one additional field to DATS.json for 10 of the datasets in CONP (1000GenomesProject, Brainspan, celltypes, mm_neo_atlas, multicenter-phantom, nhpatlas, preventad-open, refseq, SIMON-dataset and visual-working-memory), *extra_properties->CONP_status*, to indicate which category the dataset should be labelled as in the CONP portal.   Valid values are "CONP", "Canadian" or "external".  Equivalent values have been independently added to the six openpain datasets in separate PRs.

~~The values included are reasonable best estimates based on other metadata, and are not meant to be final.  The purpose of submitting this PR before receiving final confirmed values is to have the data structure in place so that front-end development can proceed; the expected outcome is that it should be possible to develop the desired visual distinction between the three categories in the interface even if category assignations of individual datasets needs correction later.~~ Final values have now been obtained and entered in the *extraProperties->CONP_status* field as appropriate