### PR TITLE
Zenodo crawler fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sudo apt-get -q install -y git-annex-standalone
 
 install:
-- pip install datalad
+- pip install datalad html2markdown
 - pip install -r scripts/dats_validator/requirements.txt
 - pip freeze
 - datalad install -r .

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -383,7 +383,6 @@ def update_dataset(zenodo_dataset, conp_dataset, token):
 
     for bucket in zenodo_dataset["files"]:
         download_file(bucket, d, dataset_dir)
-    d.save()
 
     # If DATS.json isn't in downloaded files, create new DATS.json
     if not os.path.isfile(dats_dir):
@@ -392,6 +391,8 @@ def update_dataset(zenodo_dataset, conp_dataset, token):
     # Add/update .conp-zenodo-crawler.json tracker file
     create_zenodo_tracker(zenodo_tracker_path, zenodo_dataset)
 
+    # Save all changes and push to github
+    d.save()
     d.publish(to="github")
 
 

--- a/scripts/crawl_zenodo.py
+++ b/scripts/crawl_zenodo.py
@@ -295,6 +295,7 @@ def create_new_dataset(dataset, token, force, username):
     d.save()
 
     r = d.create_sibling_github(repo_title,
+                                name="github",
                                 github_login=token,
                                 github_passwd=token)
 

--- a/scripts/crawl_zenodo.sh
+++ b/scripts/crawl_zenodo.sh
@@ -19,4 +19,4 @@ touch ${TOUCHFILE}
 
 (cd ${BASEDIR} && git pull --no-edit main master)
 
-python3 ./conp-dataset/scripts/crawl_zenodo.py --verbose -z ${TOKEN_LIST} &>>${LOGFILE}
+python3 ./scripts/crawl_zenodo.py --verbose -z ${TOKEN_LIST} &>>${LOGFILE}

--- a/scripts/crawl_zenodo.sh
+++ b/scripts/crawl_zenodo.sh
@@ -19,4 +19,4 @@ touch ${TOUCHFILE}
 
 (cd ${BASEDIR} && git pull --no-edit main master)
 
-docker run --rm -u $UID:$UID -v $HOME:$HOME -e HOME=$HOME -v ${BASEDIR}:/workdir -w /workdir bigdatalabteam/git-annex python3 ./scripts/crawl_zenodo.py --verbose -z ${TOKEN_LIST} &>>${LOGFILE}
+python3 ./conp-dataset/scripts/crawl_zenodo.py --verbose -z ${TOKEN_LIST} &>>${LOGFILE}

--- a/tests/test_zenodo_crawler.py
+++ b/tests/test_zenodo_crawler.py
@@ -39,7 +39,8 @@ def mock_zenodo_query():
                             "links": {
                                 "self": "https://www.test.file.com/nofilehere"
                             },
-                            "type": "json"
+                            "type": "json",
+                            "size": 45346
                         }
                     ]
                 }
@@ -56,6 +57,7 @@ def mock_get_test_dataset_dir():
 
 class TestZenodoCrawler(TestCase):
 
+    @mock.patch("scripts.crawl_zenodo.download_file")
     @mock.patch("scripts.crawl_zenodo.create_zenodo_tracker")
     @mock.patch("scripts.crawl_zenodo.add_description")
     @mock.patch("scripts.crawl_zenodo.switch_branch")
@@ -77,12 +79,13 @@ class TestZenodoCrawler(TestCase):
                                 mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                 mock_create_new_dats, mock_empty_conp_dois, mock_zenodo_query, mock_input,
                                 mock_store, mock_commit_push_file, mock_check_requirements, mock_switch_branch,
-                                mock_add_description, mock_create_zenodo_tracker):
+                                mock_add_description, mock_create_zenodo_tracker, mock_download_file):
         try:
             crawl()
         except Exception as e:
             self.fail("Unexpected Exception raised: " + str(e))
 
+    @mock.patch("scripts.crawl_zenodo.download_file")
     @mock.patch("scripts.crawl_zenodo.create_zenodo_tracker")
     @mock.patch("scripts.crawl_zenodo.create_new_dats")
     @mock.patch("scripts.crawl_zenodo.add_description")
@@ -105,7 +108,7 @@ class TestZenodoCrawler(TestCase):
                                      mock_get_test_dataset_dir, mock_zenodo_query,
                                      mock_input, mock_store, mock_commit_push_file, mock_check_requirements,
                                      mock_switch_branch, mock_add_description, mock_create_new_dats,
-                                     mock_create_zenodo_tracker):
+                                     mock_create_zenodo_tracker, mock_download_file):
         try:
             crawl()
         except Exception as e:

--- a/tests/test_zenodo_crawler.py
+++ b/tests/test_zenodo_crawler.py
@@ -62,7 +62,6 @@ class TestZenodoCrawler(TestCase):
     @mock.patch("scripts.crawl_zenodo.add_description")
     @mock.patch("scripts.crawl_zenodo.switch_branch")
     @mock.patch("scripts.crawl_zenodo.check_requirements", return_value="username")
-    @mock.patch("scripts.crawl_zenodo.commit_push_file")
     @mock.patch("scripts.crawl_zenodo.store")
     @mock.patch("scripts.crawl_zenodo.parse_args", return_value=mock_input())
     @mock.patch("scripts.crawl_zenodo.query_zenodo", return_value=mock_zenodo_query())
@@ -78,7 +77,7 @@ class TestZenodoCrawler(TestCase):
     def test_create_new_dataset(self, mock_datalad_add, mock_dataset, mock_repo, mock_verify_repo,
                                 mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                 mock_create_new_dats, mock_empty_conp_dois, mock_zenodo_query, mock_input,
-                                mock_store, mock_commit_push_file, mock_check_requirements, mock_switch_branch,
+                                mock_store, mock_check_requirements, mock_switch_branch,
                                 mock_add_description, mock_create_zenodo_tracker, mock_download_file):
         try:
             crawl()
@@ -91,7 +90,6 @@ class TestZenodoCrawler(TestCase):
     @mock.patch("scripts.crawl_zenodo.add_description")
     @mock.patch("scripts.crawl_zenodo.switch_branch")
     @mock.patch("scripts.crawl_zenodo.check_requirements", return_value="username")
-    @mock.patch("scripts.crawl_zenodo.commit_push_file")
     @mock.patch("scripts.crawl_zenodo.store")
     @mock.patch("scripts.crawl_zenodo.parse_args", return_value=mock_input())
     @mock.patch("scripts.crawl_zenodo.query_zenodo", return_value=mock_zenodo_query())
@@ -106,7 +104,7 @@ class TestZenodoCrawler(TestCase):
     def test_update_existing_dataset(self, mock_datalad_add, mock_dataset, mock_repo, mock_verify_repo,
                                      mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                      mock_get_test_dataset_dir, mock_zenodo_query,
-                                     mock_input, mock_store, mock_commit_push_file, mock_check_requirements,
+                                     mock_input, mock_store, mock_check_requirements,
                                      mock_switch_branch, mock_add_description, mock_create_new_dats,
                                      mock_create_zenodo_tracker, mock_download_file):
         try:


### PR DESCRIPTION
## Description
- Generated DATS.json now correctly displays total size and possible file formats
- Generated DATS.json contains zenodo logo as extra property
- Generated README.md contains dataset description in markdown format
- Crawling non-archive files (non zip files) doesn't require downloading (faster crawling)
- Time stamps in datalad logs are configured to be displayed when crawling
- Refactoring code so there is less redundant saving/committing/pushing

## Related issues (optional)
#173 
