### PR TITLE
Add McGill-EMC: RNA-seq experiment from human brain sample dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,8 @@
 [submodule "projects/Learning_Naturalistic_Structure__Processed_fMRI_dataset"]
   path = projects/Learning_Naturalistic_Structure__Processed_fMRI_dataset
   url = https://github.com/conp-bot/conp-dataset-Learning_Naturalistic_Structure__Processed_fMRI_dataset.git
+[submodule "projects/mcgill-emc-rna-seq-experiment"]
+	path = projects/mcgill-emc-rna-seq-experiment
+	url = git@github.com:zxenia/mcgill-emc-rna-seq-experiment
+	branch = master
+	datalad-id = 8cb4e8c2-51b7-11ea-8a3d-080027a96228

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,6 +69,4 @@
   url = https://github.com/conp-bot/conp-dataset-Learning_Naturalistic_Structure__Processed_fMRI_dataset.git
 [submodule "projects/mcgill-emc-rna-seq-experiment"]
 	path = projects/mcgill-emc-rna-seq-experiment
-	url = git@github.com:zxenia/mcgill-emc-rna-seq-experiment
-	branch = master
-	datalad-id = 8cb4e8c2-51b7-11ea-8a3d-080027a96228
+	url = https://github.com/zxenia/mcgill-emc-rna-seq-experiment.git


### PR DESCRIPTION
## Description
McGill-EMC: RNA-seq experiment from human brain sample.
The RNA-seq experiment from the human brain sample. The donor is 42 years old healthy male individual. Biomaterial type is primary tissue with tissue type Brodmann (1909) area 11.
The dataset contains two bigWig files. The files are located on the FTP server.

## Checklist
<!--- Task to do for an approval of the pull request -->

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [x] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [x] Every data file has a URL
- [x] Every data file can be retrieved or requires authentication
- [x] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset

The dataset is derived, there is a link for raw data in DATS file but accessing raw data requires filing a request.


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
