### PR TITLE
Restricted crawled dataset unlocking

### DIFF
--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,0 +1,87 @@
+import argparse
+import traceback
+import os
+import json
+from git import Repo
+from datalad import api
+
+
+def unlock():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=r"""
+        Script which allows to unlock a dataset given the correct token
+
+        Requirements:
+        * The token must be passed to the script via the command line
+        * Script must be run in the base directory of the dataset
+        * File '.conp-zenodo-crawler.json' must exist
+        * Dataset git repository must be set on branch 'master'
+        """,
+    )
+    parser.add_argument(
+        "token", help="Zenodo access token"
+    )
+    args = parser.parse_args()
+    token = args.token
+
+    repo = Repo()
+    annex = repo.git.annex
+    if repo.active_branch.name != "master":
+        raise Exception("Dataset repository not set to branch 'master'")
+
+    if not os.path.isfile(".conp-zenodo-crawler.json"):
+        raise Exception("'.conp-zenodo-crawler.json file not found")
+
+    with open(".conp-zenodo-crawler.json", "r") as f:
+        metadata = json.load(f)
+
+    # Ensure correct data
+    if not metadata["restricted"]:
+        raise Exception("Dataset not restricted, no need to unlock")
+    if len(metadata["private_files"]["archive_links"]) == 0 and len(metadata["private_files"]["files"]) == 0:
+        raise Exception("No restricted files to unlock")
+
+    # Set token in archive link URLs
+    if len(metadata["private_files"]["archive_links"]) > 0:
+        repo.git.checkout("git-annex")
+        changes = False
+        for link in metadata["private_files"]["archive_links"]:
+            for dir_name, dirs, files in os.walk("."):
+                for file_name in files:
+                    file_path = os.path.join(dir_name, file_name)
+                    if ".git" in file_path:
+                        continue
+                    with open(file_path, "r") as f:
+                        s = f.read()
+                    if link in s and "access_token" not in s:
+                        changes = True
+                        s = s.replace(link, link + "?access_token=" + token)
+                        with open(file_path, "w") as f:
+                            f.write(s)
+        if changes:
+            repo.git.add(".")
+            repo.git.commit("-m", "Unlock dataset")
+        repo.git.checkout("master")
+
+    # Set token in non-archive link URLs
+    if len(metadata["private_files"]["files"]) > 0:
+        datalad = api.Dataset(".")
+        for file in metadata["private_files"]["files"]:
+            annex("rmurl", file["name"], file["link"])
+            annex("addurl", file["link"] + "?access_token=" + token, "--file", file["name"], "--relaxed")
+            datalad.save()
+
+    print("Done")
+
+
+if __name__ == "__main__":
+    try:
+        unlock()
+    except Exception as e:
+        traceback.print_exc()
+    finally:
+        # Always switch branch back to master
+        repository = Repo()
+        if repository.active_branch.name != "master":
+            repository.git.checkout("master", "-f")

--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -10,7 +10,7 @@ def unlock():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description=r"""
-        Script which allows to unlock a dataset given the correct token
+        Script which allows to unlock a restricted dataset given the correct token
 
         Requirements:
         * The token must be passed to the script via the command line

--- a/tests/test_zenodo_crawler.py
+++ b/tests/test_zenodo_crawler.py
@@ -61,6 +61,8 @@ def mock_get_test_dataset_dir():
 
 class TestZenodoCrawler(TestCase):
 
+    @mock.patch("scripts.crawl_zenodo.put_unlock_script")
+    @mock.patch("scripts.crawl_zenodo.get_unlock_script")
     @mock.patch("scripts.crawl_zenodo.download_file")
     @mock.patch("scripts.crawl_zenodo.create_zenodo_tracker")
     @mock.patch("scripts.crawl_zenodo.add_description")
@@ -82,12 +84,15 @@ class TestZenodoCrawler(TestCase):
                                 mock_create_readme, mock_push_and_PR, mock_update_submodules,
                                 mock_create_new_dats, mock_empty_conp_dois, mock_zenodo_query, mock_input,
                                 mock_store, mock_check_requirements, mock_switch_branch,
-                                mock_add_description, mock_create_zenodo_tracker, mock_download_file):
+                                mock_add_description, mock_create_zenodo_tracker, mock_download_file,
+                                mock_get_unlock_script, mock_put_unlock_script):
         try:
             crawl()
         except Exception as e:
             self.fail("Unexpected Exception raised: " + str(e))
 
+    @mock.patch("scripts.crawl_zenodo.put_unlock_script")
+    @mock.patch("scripts.crawl_zenodo.get_unlock_script")
     @mock.patch("scripts.crawl_zenodo.download_file")
     @mock.patch("scripts.crawl_zenodo.create_zenodo_tracker")
     @mock.patch("scripts.crawl_zenodo.create_new_dats")
@@ -110,7 +115,8 @@ class TestZenodoCrawler(TestCase):
                                      mock_get_test_dataset_dir, mock_zenodo_query,
                                      mock_input, mock_store, mock_check_requirements,
                                      mock_switch_branch, mock_add_description, mock_create_new_dats,
-                                     mock_create_zenodo_tracker, mock_download_file):
+                                     mock_create_zenodo_tracker, mock_download_file,
+                                     mock_get_unlock_script, mock_put_unlock_script):
         try:
             crawl()
         except Exception as e:


### PR DESCRIPTION
## Description
- Restricted datasets like PERFORM have their access token stripped when crawled so that people can't just clone and `datalad get` the files
- Add script which takes a Zenodo token will reinstate the token in the correct places so that the user can access locally that dataset's files using `datalad get` if it is the right token. Usage: `python unlock.py <token>`