### PR TITLE
Fix datalad provider configuration file for authenticated loris datasets

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -141,6 +141,9 @@ def generate_datalad_provider(loris_api):
     # Regex for provider
     re_loris_api = loris_api.replace(".", "\.")
 
+    os.makedirs(
+        os.path.join(os.path.expanduser("~"), ".config", "datalad", "providers")
+    )
     with open(
         os.path.join(
             os.path.expanduser("~"), ".config", "datalad", "providers", "loris.cfg"

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -148,7 +148,7 @@ def generate_datalad_provider(loris_api):
         os.path.join(
             os.path.expanduser("~"), ".config", "datalad", "providers", "loris.cfg"
         ),
-        "w",
+        "w+",
     ) as fout:
         fout.write(
             f"""[provider:loris]                                                                    


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
@xlecours pointed out a bug with the current creation of a Datalad provider configuration file; see [logs here](https://travis-ci.org/github/CONP-PCNO/conp-dataset/jobs/672641562#L923). 
This is because the path to the config file does not exist. The brought changes makes sure that the path to the config file exist and overwrite the file if it already exists. The latter is for all authenticated dataset using loris to reuse the same provider config filename.
