### PR TITLE
Zenodo config

### DIFF
--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -98,7 +98,7 @@ class ZenodoCrawler(BaseCrawler):
         d.save()
 
     def _put_unlock_script(self, dataset_dir):
-        with open(os.path.join(dataset_dir, "unlock.py"), "w") as f:
+        with open(os.path.join(dataset_dir, "config"), "w") as f:
             f.write(self.unlock_script)
 
     def get_all_dataset_description(self):

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -100,7 +100,7 @@ class ZenodoCrawler(BaseCrawler):
     def _put_unlock_script(self, dataset_dir):
         with open(os.path.join(dataset_dir, "config"), "w") as f:
             f.write(self.unlock_script)
-        os.chmod("config", 0o744)
+        os.chmod("config", 0o755)
 
     def get_all_dataset_description(self):
         zenodo_dois = []

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -100,6 +100,7 @@ class ZenodoCrawler(BaseCrawler):
     def _put_unlock_script(self, dataset_dir):
         with open(os.path.join(dataset_dir, "config"), "w") as f:
             f.write(self.unlock_script)
+        os.chmod("config", 0o744)
 
     def get_all_dataset_description(self):
         zenodo_dois = []

--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse
 import traceback
 import os

--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 import argparse
 import traceback
 import os


### PR DESCRIPTION
## Description
Currently, the Zenodo crawler creates a configuration file `unlock.py` for authenticated dataset. To respect the convention, it should be an executable file named `config` with a shebang to indicate the language. 

This followed after a discussion with @glatard 
