### PR TITLE
FIX for the datalad provider config of loris dataset.

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -144,8 +144,7 @@ def generate_datalad_provider(loris_api):
     datalad_provider_path = os.path.join(
         os.path.expanduser("~"), ".config", "datalad", "providers"
     )
-    if not os.path.exists(datalad_provider_path):
-        os.makedirs(datalad_provider_path)
+    os.makedirs(datalad_provider_path, exist_ok=True)
     with open(os.path.join(datalad_provider_path, "loris.cfg"), "w+",) as fout:
         fout.write(
             f"""[provider:loris]                                                                    

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -141,15 +141,12 @@ def generate_datalad_provider(loris_api):
     # Regex for provider
     re_loris_api = loris_api.replace(".", "\.")
 
-    os.makedirs(
-        os.path.join(os.path.expanduser("~"), ".config", "datalad", "providers")
+    datalad_provider_path = os.path.join(
+        os.path.expanduser("~"), ".config", "datalad", "providers"
     )
-    with open(
-        os.path.join(
-            os.path.expanduser("~"), ".config", "datalad", "providers", "loris.cfg"
-        ),
-        "w+",
-    ) as fout:
+    if not os.path.exists(datalad_provider_path):
+        os.makedirs(datalad_provider_path)
+    with open(os.path.join(datalad_provider_path, "loris.cfg"), "w+",) as fout:
         fout.write(
             f"""[provider:loris]                                                                    
 url_re = {re_loris_api}/*                             


### PR DESCRIPTION
## Description
Currently, the tests for loris dataset with authentication fail after the first one is ran; see [CircleCI logs](https://app.circleci.com/pipelines/github/CONP-PCNO/conp-dataset/41/workflows/96a8a088-d1e3-4426-ac78-5e49b1262773/jobs/78/tests).  

This change checks if the Datalad provider path already exist before creating it.
