### PR TITLE
[FIX] Include config in the no-annex files

### DIFF
--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -233,7 +233,7 @@ class ZenodoCrawler(BaseCrawler):
     def add_new_dataset(self, dataset, dataset_dir):
         d = self.datalad.Dataset(dataset_dir)
         d.no_annex(".conp-zenodo-crawler.json")
-        d.no_annex("unlock.py")
+        d.no_annex("config")
         d.save()
 
         private_files = {"archive_links": [], "files": []}


### PR DESCRIPTION
## Description
After changing the filename for the dataset pre-configuration in #257, the config file is now put into the annex.
This change will bring back the expected behaviour for the configuration file.