### PR TITLE
Handle test of submodules in dataset

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -264,7 +264,7 @@ def examine(dataset, project):
         ]
 
     if len(filenames) == 0:
-        pytest.skip(f"WARNING: {dataset} No files found in the annex.")
+        return True
 
     # Remove files using FTP as it is unstable in travis.
     if os.getenv("TRAVIS", False):

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -1,13 +1,16 @@
 from contextlib import contextmanager
+from functools import reduce
 import json
 import os
 import random
 import re
 import signal
 import sys
+from typing import List, Set, Union
 
 import datalad.api as api
 import git
+from git.exc import InvalidGitRepositoryError
 import keyring
 import pytest
 
@@ -163,6 +166,40 @@ type = loris-token
         )
 
 
+def get_all_submodules(root: str) -> set:
+    """Return recursively all submodule of a dataset.
+    
+    Parameters
+    ----------
+    root : str
+        Absolute path of the submodule root.
+    
+    Returns
+    -------
+    set
+        All submodules path of a dataset.
+    """
+    try:
+        submodules: Union[Set[str], None] = {
+            os.path.join(root, submodule.path)
+            for submodule in git.Repo(root).submodules
+        }
+    except InvalidGitRepositoryError as e:
+        submodules = None
+
+    if submodules:
+        rv = reduce(
+            lambda x, y: x.union(y),
+            [
+                get_all_submodules(os.path.join(root, str(submodule)))
+                for submodule in submodules
+            ],
+        )
+        return rv | submodules
+    else:
+        return set()
+
+
 def examine(dataset, project):
     repo = git.Repo(dataset)
 
@@ -216,7 +253,15 @@ def examine(dataset, project):
         )
 
     annex_list: str = repo.git.annex("list")
-    filenames: list = re.split(r"\n[_X]+\s", annex_list)[1:]
+    filenames: List[str] = re.split(r"\n[_X]+\s", annex_list)[1:]
+
+    submodules: Set[str] = get_all_submodules(dataset)
+    for submodule in submodules:
+        annex_list = git.Repo(submodule).git.annex("list")
+        filenames += [
+            os.path.join(submodule, filename)
+            for filename in re.split(r"\n[_X]+\s", annex_list)[1:]
+        ]
 
     if len(filenames) == 0:
         pytest.skip(f"WARNING: {dataset} No files found in the annex.")

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -203,9 +203,6 @@ def get_all_submodules(root: str) -> set:
 def examine(dataset, project):
     repo = git.Repo(dataset)
 
-    # Make sure the dataset is sync to latest version.
-    repo.git.pull("origin", "master")
-
     file_names = [file_name for file_name in os.listdir(dataset)]
 
     if "README.md" not in file_names:


### PR DESCRIPTION
## Description
The current test do not allow to test the submodules within a dataset; such as [visual-working-memory](https://github.com/conpdatasets/visual-working-memory/tree/7ad5fd7fd950494e5567dc13aa760a5167ba6795) dataset.
Allowing to test a dataset submodules improve the test coverage while preventing some dataset to be skipped during the tests.
