### PR TITLE
Zenodo crawler: Modify the config script generated

### DIFF
--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,32 +1,26 @@
 #!/usr/bin/env python
-import argparse
-import traceback
-import os
 import json
+import os
+import traceback
+
 from git import Repo
 from datalad import api
 
+from tests.create_tests import project_name2env
+
 
 def unlock():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description=r"""
-        Script which allows to unlock a restricted dataset given the correct token
-
-        Requirements:
-        * The token must be passed to the script via the command line
-        * Script must be run in the base directory of the dataset
-        * File '.conp-zenodo-crawler.json' must exist
-        * Dataset git repository must be set on branch 'master'
-        """,
-    )
-    parser.add_argument(
-        "token", help="Zenodo access token"
-    )
-    args = parser.parse_args()
-    token = args.token
-
     repo = Repo()
+
+    project: str = project_name2env(repo.working_dir.split("/")[-1])
+    token: (str | None) = os.getenv(project + "_ZENODO_TOKEN", None)
+
+    if not token:
+        raise Exception(
+            f"{project}_ZENODO_TOKEN not found."
+            + "Cannot inject the Zenodo token into the git-annex urls."
+        )
+
     annex = repo.git.annex
     if repo.active_branch.name != "master":
         raise Exception("Dataset repository not set to branch 'master'")

--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 import json
 import os
+import sys
 import traceback
 
 from git import Repo
 from datalad import api
 
+sys.path.append(os.getcwd())
 from tests.create_tests import project_name2env
 
 
 def unlock():
     repo = Repo()
-
     project: str = project_name2env(repo.working_dir.split("/")[-1])
     token: (str | None) = os.getenv(project + "_ZENODO_TOKEN", None)
 
@@ -71,6 +72,7 @@ def unlock():
 
 
 if __name__ == "__main__":
+    os.chdir(os.path.dirname(__file__))
     try:
         unlock()
     except Exception as e:

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -230,6 +230,8 @@ def examine(dataset, project):
         keyring.set_password("datalad-loris", "user", username)
         keyring.set_password("datalad-loris", "password", password)
         generate_datalad_provider(loris_api)
+    elif zenodo_token:
+        pass
     elif is_authentication_required(dataset) == True:
         if os.getenv("TRAVIS_EVENT_TYPE", None) == "pull_request" or os.getenv(
             "CIRCLE_PR_NUMBER", False

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import signal
+import subprocess
 import sys
 from typing import List, Set, Union
 
@@ -225,6 +226,7 @@ def examine(dataset, project):
     username = os.getenv(project + "_USERNAME", None)
     password = os.getenv(project + "_PASSWORD", None)
     loris_api = os.getenv(project + "_LORIS_API", None)
+    zenodo_token = os.getenv(project + "_ZENODO_TOKEN", None)
 
     if username and password and loris_api:
         keyring.set_password("datalad-loris", "user", username)

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -5,7 +5,6 @@ import os
 import random
 import re
 import signal
-import subprocess
 import sys
 from typing import List, Set, Union
 


### PR DESCRIPTION
## Description
To follow convention, the config script should not assume arguments from the command line. 

Those changes allow to get the dataset Zenodo token from within the script instead of the cli.
#252 bring those changes, however, datasets authenticated through Zenodo must be updated with this new config script as otherwise they will fail the whole build; [see logs](https://app.circleci.com/pipelines/github/mathdugre/conp-dataset/176/workflows/6e446708-380d-4116-824c-b3f1fa447570/jobs/371).

## Related issues (optional)
Cherry-pick from #252 
