### PR TITLE
 [FIX] Using ssh to clone repo led to issue.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,9 @@ jobs:
     docker: *docker
 
     steps:
-      - checkout:
-          path: *workdir
+      - run:
+          name: Clone Repository
+          command: git clone https://github.com/CONP-PCNO/conp-dataset.git ~/conp-dataset
       - *restore_python_cache
       - run:
           name: Install Dependencies
@@ -38,9 +39,9 @@ jobs:
       - run:
           name: Install Dataset
           command: |
-              . ~/venv/bin/activate
-              export PATH=~/git-annex.linux:$PATH
-              datalad install -r .
+            . ~/venv/bin/activate
+            export PATH=~/git-annex.linux:$PATH
+            datalad install -r .
       - persist_to_workspace:
           root: *workdir
           paths:


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
CircleCI checkout using ssh by default, however, this seems to lead to issues with datasets submodules; see [build logs](https://app.circleci.com/pipelines/github/CONP-PCNO/conp-dataset/64/workflows/193e4ea9-1efb-4b1b-b2a7-4eae2aa14791/jobs/114) of #275 . 
Those changes clone the repository using https.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
#275 pointed out this issue