### PR TITLE
Change to the Circle CI Build configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs:
             - ~/venv
           key: v1.3-python-{{ .Branch }}
       - run:
-          name: Install Dataset
+          name: Install CONP-DATS Validator
           command: |
-              . ~/venv/bin/activate
-              export PATH=~/git-annex.linux:$PATH
-              datalad install -r .
+            . ~/venv/bin/activate
+            export PATH=~/git-annex.linux:$PATH
+            datalad install scripts/dats_validator/conp-dats
       - persist_to_workspace:
           root: *workdir
           paths:
@@ -52,6 +52,8 @@ jobs:
     parallelism: 2
 
     steps:
+      - checkout:
+          path: *workdir
       - attach_workspace:
           at: *workdir
       - *restore_python_cache

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -197,6 +197,7 @@ def get_all_submodules(root: str) -> set:
 
 
 def examine(dataset, project):
+    api.install(dataset)
     repo = git.Repo(dataset)
 
     file_names = [file_name for file_name in os.listdir(dataset)]


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
Currently, the configuration use Datalad to install all dataset during the build phase. This is problematic as when a dataset fails to download the whole test suite fails ; as right now.

@glatard proposed to install the dataset individually when needed. This has two main advantages: (1) only tests unable to install via Datalad will fail and (2) it will speedup the test suite when only a sample of test are run as described in #232.
