### PR TITLE
Fix pattern lookup for minimal testing

### DIFF
--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -68,7 +68,7 @@ def minimal_tests(datasets: List[str], pr_files: List[str]):
     for pr_filename in pr_files:
         if pr_filename.startswith("projects/"):
             for dataset in datasets:
-                if dataset in pr_filename:
+                if re.match(f"{dataset}\/", pr_filename) or pr_filename == dataset:
                     modified_datasets.append(dataset)
                     break
         else:


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
When a PR is made, the CI script will try to find the minimal number of tests to be performed, however, there is a problem with the implementation for finding to which datasets modified files are part of.

These changes solve this issue.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
That issue was found in #286.