### PR TITLE
Fix calculation of size of annexed files

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -54,7 +54,7 @@ def get_annexed_file_size(dataset, file_path):
         Size of the annexed file in Bytes.
     """
     try:
-        info_ouput = git.Repo(dataset).git.annex(
+        info_output = git.Repo(dataset).git.annex(
             "info", os.path.join(dataset, file_path), json=True, bytes=True,
         )
         metadata = json.loads(info_output)


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
The refactoring of the function in #285 broke the calculation of the annexed files size.
This change fixes this issue.
