### PR TITLE
Crawler bug fixes and feature additions

### DIFF
--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -231,6 +231,12 @@ class BaseCrawler:
             branch_name = "conp-bot/" + clean_title
             dataset_dir = os.path.join("projects", clean_title)
             d = self.datalad.Dataset(dataset_dir)
+            # Add github token to individual dataset remote urls
+            origin = git.Repo(dataset_dir).remote("origin")
+            origin_url = next(origin.urls)
+            if "@" not in origin_url:
+                origin.set_url(origin_url.replace("https://", "https://" + self.github_token + "@"))
+
             if branch_name not in self.repo.remotes.origin.refs:  # New dataset
                 self.repo.git.checkout("-b", branch_name)
                 repo_title = ("conp-dataset-" + dataset_description["title"])[0:100]

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -232,11 +232,13 @@ class BaseCrawler:
             dataset_dir = os.path.join("projects", clean_title)
             d = self.datalad.Dataset(dataset_dir)
             # Add github token to individual dataset remote urls
-            origin = git.Repo(dataset_dir).remote("origin")
-            origin_url = next(origin.urls)
-            if "@" not in origin_url:
-                origin.set_url(origin_url.replace("https://", "https://" + self.github_token + "@"))
-
+            try:
+                origin = git.Repo(dataset_dir).remote("origin")
+                origin_url = next(origin.urls)
+                if "@" not in origin_url:
+                    origin.set_url(origin_url.replace("https://", "https://" + self.github_token + "@"))
+            except git.exc.NoSuchPathError:
+                pass
             if branch_name not in self.repo.remotes.origin.refs:  # New dataset
                 self.repo.git.checkout("-b", branch_name)
                 repo_title = ("conp-dataset-" + dataset_description["title"])[0:100]

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -393,10 +393,11 @@ Functional checks:
         # Add file count
         num = 0
         for file in os.listdir(dataset_dir):
+            file_path = os.path.join(dataset_dir, file)
             if file[0] == "." or file == "DATS.json" or file == "README.md":
                 continue
-            elif os.path.isdir(file):
-                num += sum([len(files) for r, d, files in os.walk(file)])
+            elif os.path.isdir(file_path):
+                num += sum([len(files) for r, d, files in os.walk(file_path)])
             else:
                 num += 1
         if "extraProperties" not in data.keys():

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -396,12 +396,7 @@ Functional checks:
             if file[0] == "." or file == "DATS.json" or file == "README.md":
                 continue
             elif os.path.isdir(file):
-                num += sum(
-                    [
-                        len(list(filter(lambda x: x[0] != ".", files)))
-                        for r, d, files in os.walk(file)
-                    ]
-                )
+                num += sum([len(files) for r, d, files in os.walk(file)])
             else:
                 num += 1
         if "extraProperties" not in data.keys():

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -40,7 +40,7 @@ class OSFCrawler(BaseCrawler):
                     file["relationships"]["files"]["links"]["related"]["href"],
                     folder_path,
                     os.path.join(inner_path, file["attributes"]["name"]),
-                    d, annex
+                    d, annex, sizes
                 )
             # Handle single files
             elif file["attributes"]["kind"] == "file":

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -3,6 +3,7 @@ from git import Repo
 import os
 import json
 import requests
+import humanize
 
 
 def _create_osf_tracker(path, dataset):
@@ -27,7 +28,7 @@ class OSFCrawler(BaseCrawler):
             print("OSF query: {}".format(query))
         return results
 
-    def _download_files(self, link, current_dir, inner_path, d, annex):
+    def _download_files(self, link, current_dir, inner_path, d, annex, sizes):
         r = requests.get(link)
         files = r.json()["data"]
         for file in files:
@@ -43,6 +44,8 @@ class OSFCrawler(BaseCrawler):
                 )
             # Handle single files
             elif file["attributes"]["kind"] == "file":
+                # Remember file size
+                sizes.append(file["attributes"]["size"])
                 # Handle zip files
                 if file["attributes"]["name"].split(".")[-1] == "zip":
                     d.download_url(file["links"]["download"], path=os.path.join(inner_path, ""), archive=True)
@@ -98,6 +101,20 @@ class OSFCrawler(BaseCrawler):
                         }
                     ],
                     "keywords": keywords,
+                    "distributions": [
+                        {
+                            "size": 0,
+                            "unit": {"value": "B"},
+                            "access": {
+                                "landingPage": dataset["links"]["html"],
+                                "authorizations": [
+                                    {
+                                        "value": "public"
+                                    }
+                                ],
+                            },
+                        }
+                    ],
                     "extraProperties": [
                         {
                             "category": "logo",
@@ -128,8 +145,11 @@ class OSFCrawler(BaseCrawler):
         d.no_annex(".conp-osf-crawler.json")
         d.save()
         annex = Repo(dataset_dir).git.annex
-
-        self._download_files(dataset["files"], dataset_dir, "", d, annex)
+        dataset_size = []
+        self._download_files(dataset["files"], dataset_dir, "", d, annex, dataset_size)
+        dataset_size, dataset_unit = humanize.naturalsize(sum(dataset_size)).split(" ")
+        dataset["distributions"][0]["size"] = dataset_size
+        dataset["distributions"][0]["unit"]["value"] = dataset_unit
 
         # Add .conp-osf-crawler.json tracker file
         _create_osf_tracker(
@@ -163,8 +183,11 @@ class OSFCrawler(BaseCrawler):
             d = self.datalad.Dataset(dataset_dir)
             annex = Repo(dataset_dir).git.annex
 
-            for file in dataset_description["files"]:
-                self._download_files(file, dataset_dir, "", d, annex)
+            dataset_size = []
+            self._download_files(dataset_description["files"], dataset_dir, "", d, annex, dataset_size)
+            dataset_size, dataset_unit = humanize.naturalsize(sum(dataset_size)).split(" ")
+            dataset_description["distributions"][0]["size"] = dataset_size
+            dataset_description["distributions"][0]["unit"]["value"] = dataset_unit
 
             # Add .conp-osf-crawler.json tracker file
             _create_osf_tracker(

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -155,6 +155,22 @@ class ZenodoCrawler(BaseCrawler):
             ).split(" ")
             dataset_size = float(dataset_size)
 
+            # Get creators and assign roles if it exists
+            creators = list(map(lambda x: {"name": x["name"]}, metadata["creators"]))
+            if "contributors" in metadata.keys():
+                for contributor in metadata["contributors"]:
+                    if contributor["type"] == "ProjectLeader":
+                        for creator in creators:
+                            if creator["name"].lower() == contributor["name"].lower():
+                                creator["roles"] = [{"value": "Principal Investigator"}]
+                                break
+                        else:
+                            creators.append(
+                                {
+                                    "name": contributor["name"],
+                                    "roles": [{"value": "Principal Investigator"}]}
+                            )
+
             zenodo_dois.append(
                 {
                     "identifier": {
@@ -166,9 +182,7 @@ class ZenodoCrawler(BaseCrawler):
                     "title": metadata["title"],
                     "files": files,
                     "doi_badge": dataset["conceptdoi"],
-                    "creators": list(
-                        map(lambda x: {"name": x["name"]}, metadata["creators"])
-                    ),
+                    "creators": creators,
                     "description": metadata["description"],
                     "version": metadata["version"]
                     if "version" in metadata.keys()

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -5,6 +5,7 @@ import os
 import sys
 import traceback
 sys.path.append(os.path.abspath(os.path.join(os.path.expanduser("~"), "conp-dataset")))
+sys.path.append(os.path.join("/tmp", "conp-dataset"))
 from scripts.Crawlers.ZenodoCrawler import ZenodoCrawler
 from scripts.Crawlers.OSFCrawler import OSFCrawler
 

--- a/scripts/crawl.sh
+++ b/scripts/crawl.sh
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-BASEDIR=$HOME/conp-dataset
+BASEDIR=/tmp/conp-dataset
 mkdir -p ${BASEDIR}/log
 DATE=$(date)
 LOGFILE=$(mktemp ${BASEDIR}/log/crawler-XXXXX.log)


### PR DESCRIPTION
## Description
- When crawling datasets from Zenodo, when the crawler detects the presence of a contributor of the type "Project Leader", it will map it to the role "Principal Investigator" in the DATS.json file. It only allows the role of Principal Investigator for one creator for the entire list of creators
- OSF crawler now adds total file size, unit and number in generated DATS file
- OSF crawler now adds homepage link in DATS file

## Related issues (optional)
https://github.com/CONP-PCNO/conp-portal/issues/254
