### PR TITLE
Modify script to unlock authenticated dataset with Zenodo

### DIFF
--- a/scripts/unlock.py
+++ b/scripts/unlock.py
@@ -1,14 +1,37 @@
 #!/usr/bin/env python
 import json
 import os
+import re
 import sys
 import traceback
 
 from git import Repo
 from datalad import api
 
-sys.path.append(os.getcwd())
-from tests.functions import project_name2env
+def project_name2env(project_name: str) -> str:
+    """Convert the project name to a valid ENV var name.
+
+    The ENV name for the project must match the regex `[a-zA-Z_]+[a-zA-Z0-9_]*`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project.
+
+    Return
+    ------
+    project_env: str
+        A valid ENV name for the project.
+    """
+    project_name = project_name.replace("-", "_")
+    project_env = re.sub("[_]+", "_", project_name)  # Remove consecutive `_`
+    project_env = re.sub("[^a-zA-Z0-9_]", "", project_env)
+
+    # Env var cannot start with number
+    if re.compile("[0-9]").match(project_env[0]):
+        project_env = "_" + project_env
+
+    return project_env.upper()
 
 
 def unlock():


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This change allows the crawler unlock script to run from anywhere. This is useful when someone when to run it from a dataset root.
