### PR TITLE
FSCK ignore dataset metadata

### DIFF
--- a/tests/template.py
+++ b/tests/template.py
@@ -81,8 +81,14 @@ class Template(object):
         completed = False
         with timeout(TIME_LIMIT):
             try:
+                # Currently some dataset have DataLad metadata, however, those are
+                # out-of-date. Since the datasets are still functional but this leads can
+                # lead to test failure, the DataLad metadata are ignore when running fsck.
+                #
+                # In the future, those metadata are likely to be removed. When this occurs,
+                # this the `exclude=".datalad/metadata/**"` argument should be removed.
                 fsck_output = git.Repo(dataset).git.annex(
-                    "fsck", fast=True, quiet=True,
+                    "fsck", fast=True, quiet=True, exclude=".datalad/metadata/**",
                 )
                 if fsck_output:
                     pytest.fail(fsck_output, pytrace=False)


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This is following some inconsistency to verify the file system integrity when the
dataset contains metadata #303 .


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
fix #303
