### PR TITLE
[REFACTOR] Renamed the Docker image used by CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &docker
-    - image: mathdugre/conp-dataset:v1.1
+    - image: mathdugre/ci-conp-dataset:v1
 
   - &workdir ~/conp-dataset
 


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This allows to use the _conp-dataset_ image user usage; such as local testing and latest
version of the environment required to install (or create) datasets.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
#9 addresses a use case for this change.
