### PR TITLE
[FIX] pull_number was undefined.

### DIFF
--- a/tests/create_tests.py
+++ b/tests/create_tests.py
@@ -9,7 +9,8 @@ import requests
 def get_datasets():
     datasets: List[str] = list(map(lambda x: x.path, Repo(".").submodules))
 
-    if os.getenv("CIRCLE_PR_NUMBER", False):
+    pull_number = os.getenv("CIRCLE_PR_NUMBER", False)
+    if pull_number:
         response = requests.get(
             f"https://api.github.com/repos/CONP-PCNO/conp-dataset/pulls/{pull_number}/files"
         )


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
When deprecating TravisCI in #307, a bug was introduced for the detection of files on new PRs. This is seen the CircleCI logs [here](https://app.circleci.com/pipelines/github/CONP-PCNO/conp-dataset/199/workflows/66f3437a-ae27-46f7-80b5-2578830b2d83/jobs/365/steps).
This change is to fix the bug.
