### PR TITLE
Improved template for broken datasets

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset-error.md
+++ b/.github/ISSUE_TEMPLATE/dataset-error.md
@@ -1,24 +1,17 @@
 ---
 name: Broken Dataset
 about: Report an issue with the installation of a dataset.
-title: 'Resulted error from dataset installation'
+title: '<Dataset name>'
 labels: 'Broken Dataset'
 assignees: ''
 
 ---
 
-<!--- Provide a general summary of the issue in the title above -->
+* Test build: 
+<!--- Add a link to the CircleCI test build here -->
 
-## Current Behavior
-<!--- Tell us what happens instead of the expected behavior. Add an example with all 
- the information needed to reproduce the bug (descriptors, inputs, etc) -->
+* Standard error:
+<!-- Copy the standard error related to the broken dataset here -->
 
-## Environment
-<!--- Information about the execution environment, in particular: Python version, Docker/Singularity version
- if relevant -->
-
-## Possible fix (optional)
-<!--- Not obligatory, but suggest an idea to fix the prroblem -->
-
-## Related issues (optional)
-<!--- Link any related issue -->
+* Help requested from:
+<!-- Tag relevant people with their GitHub handles -->


### PR DESCRIPTION
The previous template was more appropriate for software bugs. Edited it to only request the link to a failed CircleCI build, a copy of the error, and suggested names of people to look at it.