### PR TITLE
[WIP] Added cneuromod umbrella dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,3 +112,6 @@
 	path = projects/preventad-open-bids
 	url = https://github.com/conpdatasets/preventad-open-bids.git
 
+[submodule "projects/cneuromod"]
+	path = projects/cneuromod
+	url = https://github.com/glatard/cneuromod.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -112,6 +112,3 @@
 	path = projects/preventad-open-bids
 	url = https://github.com/conpdatasets/preventad-open-bids.git
 
-[submodule "projects/cneuromod"]
-	path = projects/cneuromod
-	url = https://github.com/courtois-neuromod/cneuromod.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -111,3 +111,7 @@
 [submodule "projects/preventad-open-bids"]
 	path = projects/preventad-open-bids
 	url = https://github.com/conpdatasets/preventad-open-bids.git
+
+[submodule "projects/cneuromod"]
+	path = projects/cneuromod
+	url = https://github.com/courtois-neuromod/cneuromod.git


### PR DESCRIPTION
## Description

This is the umbrella dataset of the Courtois Neuromod project, available [here](https://github.com/courtois-neuromod/cneuromod). The sub-datasets `anat`, `movie10`, `hcptrt` and `friends` are not public yet, but it should be quite easy to add them when they are. Dataset was already a DataLad repository, only a DATS file was required.

## Checklist

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ x ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ x ] Every data file has a URL
- [ x ] Every data file can be retrieved or requires authentication
- [ x ] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
