### PR TITLE
Add validation of required extra properties and their values

### DIFF
--- a/scripts/dats_validator/README.md
+++ b/scripts/dats_validator/README.md
@@ -1,9 +1,14 @@
 # Simple dats validator
 
+Validation workflow:
+
+1. Validates against CONP DATS schema
+2. Validates required extra properties and their values where applicable
+
 **Usage:**
-<pre>python validator.py --file=doc.json</pre>
+<pre>python validator.py --file=DATS.json</pre>
 
 **Test valid and invalid examples:**
 
-- valid and invalid dats files are in examples directory
+- valid and invalid DATS files are in examples directory
 - tests located in tests/

--- a/scripts/dats_validator/examples/invalid_dats.json
+++ b/scripts/dats_validator/examples/invalid_dats.json
@@ -1,1443 +1,2879 @@
 {
-	"version": "1.0",
-	"privacy": "public open",
-	"licenses": [
-		{
-			"name": "BY-NC-SA"
-		}
-	],
-	"types": [
-		{
-			"information": {
-				"value": "genomics"
-			}
-		}
-	],
-	"title": "1000 Genomes Project",
-	"description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
-	"storedIn": {
-		"name" : "European Bioinformatics Institute"
-	},
-	"primaryPublications" : [
-		{
-			"title": "A global reference for human genetic variation",
-			"dates": [
-				{
-					"type": {
-						"value":"Primary reference publication date"
-					},
-					"date": "2015-10-01 00:00:00"
-				}
-			],
-			"authors": [
-				{
-				"name":"1000 Genomes Project"
-				}
-			]
-		}
-	],
-	"isAbout": [
-		{
-			"identifier": {
-				"identifier": "9606",
-				"identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/9606"
-			},
-			"name":"Homo sapiens"
-		}
-	],
-	"dates": [
-		{
-			"type": {
-				"value":"CONP DATS JSON fileset creation date"
-			},
-			"date": "2019-06-17 13:16:33"
-		}
-	],
-	"hasPart": [
-		{
-			"test":"Chromosome 1",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"6056764"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"235061"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 10",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3769238"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"144656"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 11",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3793612"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"143588"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 12",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3629625"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"146902"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 13",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2705190"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"113204"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 14",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2490590"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"99773"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 15",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2273944"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"89809"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 16",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2528069"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"84171"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 17",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2143622"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"87646"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 18",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"2151346"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"82396"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 19",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"1648250"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"67728"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 2",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"6689892"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"254832"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 20",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"1702558"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"62847"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 21",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"1037591"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"43733"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 22",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"1019265"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"40550"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 3",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"5510472"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"213759"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 4",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"5430270"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"217157"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 5",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"4978871"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"196285"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 6",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"4732160"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"193158"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 7",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"4450904"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"170788"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 8",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"4368964"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"151538"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome 9",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3355633"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"124138"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Mitochondrial genome",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-10-02 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3587"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"20"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": ""
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome X",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"3191768"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"210679"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title":"Chromosome Y",
-			"creators": [
-				{
-					"name": "1000 Genomes Project"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "genomics"
-					}
-				}
-			],
-			"dates": [
-				{
-					"type": {
-						"value":"source .vcf file creation date"
-					},
-					"date": "2015-02-18 00:00:00"
-				}
-			],
-			"storedIn": {
-				"name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
-				"description": "Gzipped .vcf file containing sequence variations"
-			},
-			"dimensions": [
-				{
-					"name": {
-						"value": "Count of Single Nucleotide Polymorphism variants"
-					},
-					"values": [
-						"60505"
-					]
-				},
-				{
-					"name": {
-						"value": "Count of single-nucleotide insertion and deletion events"
-					},
-					"values": [
-						"1314"
-					]
-				}
-			],
-			"extraProperties": [
-				{
-					"category": "FTP link to gzipped FASTA file containing reference DNA sequence",
-					"values": [
-						{
-							"value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
-						}
-					]
-				}
-			]
-		}
-	],
-	"extraProperties": [
-		{
-			"category": "contact",
-			"values": [
-				{
-					"value": "Jennifer Tremblay-Mercier, Research Co-ordinator, jennifer.tremblay-mercier@douglas.mcgill.ca, 514-761-6131 #3329"
-				}
-			]
-		}
-	]
+  "identifier": {
+    "identifier": "dummy",
+    "identifierSource": "DOI"
+  },
+  "version": "1.0",
+  "privacy": "public open",
+  "license": [
+    {
+      "name": "BY-NC-SA"
+    }
+  ],
+  "creators": [
+    {
+      "name": "1000 Genomes Project"
+    }
+  ],
+  "types": [
+    {
+      "information": {
+        "value": "genomics"
+      }
+    }
+  ],
+  "title": "1000 Genomes Project",
+  "description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
+  "storedIn": {
+    "name": "European Bioinformatics Institute"
+  },
+  "primaryPublications": [
+    {
+      "identifier": {
+        "identifier": "https://doi.org/10.1038/nature15393"
+      },
+      "title": "A global reference for human genetic variation",
+      "dates": [
+        {
+          "type": {
+            "value": "Primary reference publication date"
+          },
+          "date": "2015-10-01 00:00:00"
+        }
+      ],
+      "authors": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ]
+    }
+  ],
+  "isAbout": [
+    {
+      "identifier": {
+        "identifier": "9606",
+        "identifierSource": "https://www.ncbi.nlm.nih.gov/taxonomy/9606"
+      },
+      "name": "Homo sapiens"
+    }
+  ],
+  "dates": [
+    {
+      "type": {
+        "value": "CONP DATS JSON fileset creation date"
+      },
+      "date": "2019-07-31 11:21:58"
+    }
+  ],
+  "distributions": [
+    {
+      "formats": [
+        ".VCF",
+        "FASTA"
+      ],
+      "size": 16.2,
+      "unit": {
+        "value": "GB"
+      },
+      "access": {
+        "landingPage": "https://www.internationalgenome.org/",
+        "authorizations": [
+          {
+            "value": "public"
+          }
+        ]
+      }
+    }
+  ],
+  "keywords": [
+    {
+      "value": "genomics"
+    }
+  ],
+  "hasPart": [
+    {
+      "title": "Chromosome 1",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.19,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 1",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "6056764"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "235061"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "External"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 10",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 755,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 10",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3769238"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "144656"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "conp_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 11",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 749,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 11",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3793612"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "143588"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subject",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 12",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 723,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 12",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3629625"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "146902"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 13",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 543,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 13",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2705190"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "113204"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 14",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 494,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 14",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2490590"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "99773"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 15",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 447,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 15",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2273944"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "89809"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 16",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 483,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 16",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2528069"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "84171"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 17",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 424,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 17",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2143622"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "87646"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 18",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 426,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 18",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2151346"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "82396"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 19",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 351,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 19",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1648250"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "67728"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 2",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.28,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 2",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "6689892"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "254832"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 20",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 334,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 20",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1702558"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "62847"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 21",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 213,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 21",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1037591"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "43733"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 22",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 209,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 22",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1019265"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "40550"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 3",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.08,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 3",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "5510472"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "213759"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 4",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.09,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 4",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "5430270"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "217157"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 5",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 966,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 5",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4978871"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "196285"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 6",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 976,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 6",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4732160"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "193158"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 7",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 886,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 7",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4450904"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "170788"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 8",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 841,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 8",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4368964"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "151538"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 9",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 657,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 9",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3355633"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "124138"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Mitochondrial genome",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-10-02 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 202,
+          "unit": {
+            "value": "KB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Mitochondrial genome",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3587"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "20"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": ""
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome X",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.87,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome X",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3191768"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "210679"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome Y",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 5.73,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome Y",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "60505"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "1314"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "extraProperties": [
+    {
+      "category": "contact",
+      "values": [
+        {
+          "value": "info@1000genomes.org"
+        }
+      ]
+    },
+    {
+      "category": "CONP_status",
+      "values": [
+        {
+          "value": "external"
+        }
+      ]
+    },
+    {
+      "category": "files",
+      "values": [
+        {
+          "value": "25"
+        }
+      ]
+    },
+    {
+      "category": "subjects",
+      "values": [
+        {
+          "value": "2504"
+        }
+      ]
+    },
+    {
+      "category": "logo",
+      "values": [
+        {
+          "value": "logo.png"
+        }
+      ]
+    }
+  ]
 }

--- a/scripts/dats_validator/examples/valid_dats.json
+++ b/scripts/dats_validator/examples/valid_dats.json
@@ -1,551 +1,2887 @@
 {
-	"identifier": {
-		"identifier": "https://doi.org/10.5281/zenodo.3405490",
-		"identifierSource": "DOI"
-	},
-	"version": "1.0.0",
-	"privacy": "public open",
-	"licenses": [
-		{
-			"name": "https://alleninstitute.org/legal/terms-use/"
-		}
-	],
-	"creators": [
-		{
-			"name": "The Allen Institute for Brain Science"
-		}
-	],
-	"types": [
-		{
-			"information": {
-				"value": "transcriptomics"
-			}
-		}
-	],
-	"title": "NIH Blueprint Non-Human Primate Atlas",
-	"description": "The NIH Blueprint Non-Human Primate (NHP) Atlas consists of a suite of gene expression and neuroanatomical data for exploring the cellular and molecular architecture of the developing rhesus macaque brain.",
-	"storedIn": {
-		"name" : "The Allen Institute for Brain Science"
-	},
-	"primaryPublications" : [
-		{
-			"identifier": {
-				"identifier": "https://dx.doi.org/10.1093%2Fnar%2Fgks1042"
-			},
-			"title": "Allen Brain Atlas: an integrated spatio-temporal portal for exploring the central nervous system",
-			"dates": [
-				{
-					"type": {
-						"value":"Primary reference publication date"
-					},
-					"date": "2012-11-27 00:00:00"
-				}
-			],
-			"authors": [
-				{
-				"name":"Susan M. Sunkin, Lydia Ng, Chris Lau, Tim Dolbeare, Terri L. Gilbert, Carol L. Thompson, Michael Hawrylycz, and Chinh Dang"
-				}
-			]
-		}
-	],
-	"isAbout": [
-		{
-			"identifier": {
-				"identifier": "9483",
-				"identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/9483"
-			},
-			"name":"Callithrix jacchus"
-		}
-	],
-	"dates": [
-		{
-			"type": {
-				"value":"CONP DATS JSON fileset creation date"
-			},
-			"date": "2019-09-06 13:54:24"
-		}
-	],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 7,
-		        "unit" : {
-            			"value": "GB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-	"keywords": [
-		{
-			"value" : "transcriptomics"
-		}
-	],
-	"hasPart": [
-		{
-			"title":"Normalised LMD microarray expression values + probe and sample metadata",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "developmental transcriptome"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Normalised LMD microarray expression values + probe and sample metadata",
-		"distributions": [
-		        {
-				"formats": [
-					".CEL",
-					".JPG",
-					"DICOM"
-            			],
-				"size" : 744,
-		        "unit" : {
-            				"value": "MB"
-		       	},
-				"access": {
-					"landingPage": "http://www.blueprintatlas.org/static/download/",
-					"authorizations": [
-						{
-							"value": "public"
-						}
-					]
-				}
-			}
-		],
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/api/v2/well_known_file_download/298764404",
-				"description": "Zipped file archive"
-			}
-		},
-		{
-			"title":"Normalised macrodissection microarray expression values + probe and sample metadata",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "developmental transcriptome"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Normalised macrodissection microarray expression values + probe and sample metadata",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            ],
-			"size" : 25,
-		        "unit" : {
-            			"value": "MB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/api/v2/well_known_file_download/298764384",
-				"description": "Zipped file archive"
-			}
-		},
-		{
-			"title":"Meta-information and URLs for downloading raw microarray files",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "developmental transcriptome"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Meta-information and URLs for downloading raw microarray files",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 1.67,
-		        "unit" : {
-            			"value": "MB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/microarray/well_data_files.xml",
-				"description": "xml file"
-			}
-		},
-		{
-			"title":"Neuroanatomical guides for prenatal LMD sample isolation",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "neuroanatomical images"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Neuroanatomical guides for prenatal LMD sample isolation",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 1,
-		        "unit" : {
-            			"value": "KB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://download.alleninstitute.org/nhp/Prenatal_Macaque_LMD_Microarray/neuroanatomical_guides_for_LMD_sampling/",
-				"description": "Directory containing 144 .JPG files + 1 summary document"
-			}
-		},
-		{
-			"title":"Transcriptional architecture of the primate neocortex",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "neuroanatomical images"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Transcriptional architecture of the primate neocortex",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 52,
-		        "unit" : {
-            			"value": "KB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://download.alleninstitute.org/nhp/Transcriptional_Architecture_of_the_Primate_Neocortex/",
-				"description": "Directory containing 226 .CEL files + 3 summary/metadata documents"
-			}
-		},
-		{
-			"title":"14349_MRI.zip",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "neuroanatomical images"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 1",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],
-	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 4.5,
-		        "unit" : {
-            			"value": "MB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/api/v2/well_known_file_download/147139113",
-				"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 1"
-			}
-		},
-		{
-			"title":"14447_MRI.zip",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "neuroanatomical images"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 2",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 4.0,
-		        "unit" : {
-            			"value": "MB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/api/v2/well_known_file_download/147139119",
-				"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 2"
-			}
-		},
-		{
-			"title":"14868_MRI.zip",
-			"creators": [
-				{
-					"name": "The Allen Institute for Brain Science"
-				}
-			],
-			"types": [
-				{
-					"information": {
-						"value": "neuroanatomical images"
-					}
-				}
-			],
-			"licenses": [
-				{
-					"name": "https://alleninstitute.org/legal/terms-use/"
-				}
-			],
-			"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 3",
-			"keywords": [
-				{
-					"value" : "transcriptomics"
-				}
-			],	"distributions": [
-	        {
-			"formats": [
-				".CEL",
-				".JPG",
-				"DICOM"
-            		],
-			"size" : 4.2,
-		        "unit" : {
-            			"value": "MB"
-		        },
-			"access": {
-				"landingPage": "http://www.blueprintatlas.org/static/download/",
-				"authorizations": [
-					{
-						"value": "public"
-					}
-				]
-			}
-		}
-	],
-
-			"version": "1.0.0",
-			"storedIn": {
-				"name": "http://blueprintnhpatlas.org/api/v2/well_known_file_download/147139125",
-				"description": "Zipped cerebral MRI images from adult (48 months) rhesus macaque, specimen 3"
-			}
-		}
-	],
-	"extraProperties": [
-		{
-			"category": "contact",
-			"values": [
-				{
-					"value": "http://www.alleninstitute.org#contact-form"
-				}
-			]
-		},
-		{
-			"category": "CONP_status",
-			"values": [
-				{
-					"value": "external"
-				}
-			]
-		},
-		{
-			"category": "files",
-			"values": [
-				{
-					"value": "385"
-				}
-			]
-		},
-		{
-			"category": "logo",
-			"values": [
-				{
-					"value": "logo.jpg"
-				}
-			]
-		}
-	]
+  "identifier": {
+    "identifier": "dummy",
+    "identifierSource": "DOI"
+  },
+  "version": "1.0",
+  "privacy": "public open",
+  "licenses": [
+    {
+      "name": "BY-NC-SA"
+    }
+  ],
+  "creators": [
+    {
+      "name": "1000 Genomes Project"
+    }
+  ],
+  "types": [
+    {
+      "information": {
+        "value": "genomics"
+      }
+    }
+  ],
+  "title": "1000 Genomes Project",
+  "description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
+  "storedIn": {
+    "name": "European Bioinformatics Institute"
+  },
+  "primaryPublications": [
+    {
+      "identifier": {
+        "identifier": "https://doi.org/10.1038/nature15393"
+      },
+      "title": "A global reference for human genetic variation",
+      "dates": [
+        {
+          "type": {
+            "value": "Primary reference publication date"
+          },
+          "date": "2015-10-01 00:00:00"
+        }
+      ],
+      "authors": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ]
+    }
+  ],
+  "isAbout": [
+    {
+      "identifier": {
+        "identifier": "9606",
+        "identifierSource": "https://www.ncbi.nlm.nih.gov/taxonomy/9606"
+      },
+      "name": "Homo sapiens"
+    }
+  ],
+  "dates": [
+    {
+      "type": {
+        "value": "CONP DATS JSON fileset creation date"
+      },
+      "date": "2019-07-31 11:21:58"
+    }
+  ],
+  "distributions": [
+    {
+      "formats": [
+        ".VCF",
+        "FASTA"
+      ],
+      "size": 16.2,
+      "unit": {
+        "value": "GB"
+      },
+      "access": {
+        "landingPage": "https://www.internationalgenome.org/",
+        "authorizations": [
+          {
+            "value": "public"
+          }
+        ]
+      }
+    }
+  ],
+  "keywords": [
+    {
+      "value": "genomics"
+    }
+  ],
+  "hasPart": [
+    {
+      "title": "Chromosome 1",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.19,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 1",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "6056764"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "235061"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 10",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 755,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 10",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3769238"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "144656"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 11",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 749,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 11",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3793612"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "143588"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 12",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 723,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 12",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3629625"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "146902"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 13",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 543,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 13",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2705190"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "113204"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 14",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 494,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 14",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2490590"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "99773"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 15",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 447,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 15",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2273944"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "89809"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 16",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 483,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 16",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2528069"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "84171"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 17",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 424,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 17",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2143622"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "87646"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 18",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 426,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 18",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "2151346"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "82396"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 19",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 351,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 19",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1648250"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "67728"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 2",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.28,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 2",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "6689892"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "254832"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 20",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 334,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 20",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1702558"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "62847"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 21",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 213,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 21",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1037591"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "43733"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 22",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 209,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 22",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "1019265"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "40550"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 3",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.08,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 3",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "5510472"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "213759"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 4",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.09,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 4",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "5430270"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "217157"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 5",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 966,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 5",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4978871"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "196285"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 6",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 976,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 6",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4732160"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "193158"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 7",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 886,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 7",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4450904"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "170788"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 8",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 841,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 8",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "4368964"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "151538"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome 9",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 657,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome 9",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3355633"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "124138"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Mitochondrial genome",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-10-02 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 202,
+          "unit": {
+            "value": "KB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Mitochondrial genome",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3587"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "20"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": ""
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome X",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 1.87,
+          "unit": {
+            "value": "GB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome X",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "3191768"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "210679"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Chromosome Y",
+      "creators": [
+        {
+          "name": "1000 Genomes Project"
+        }
+      ],
+      "types": [
+        {
+          "information": {
+            "value": "genomics"
+          }
+        }
+      ],
+      "dates": [
+        {
+          "type": {
+            "value": "source .vcf file creation date"
+          },
+          "date": "2015-02-18 00:00:00"
+        }
+      ],
+      "keywords": [
+        {
+          "value": "genomics"
+        }
+      ],
+      "distributions": [
+        {
+          "formats": [
+            ".VCF"
+          ],
+          "size": 5.73,
+          "unit": {
+            "value": "MB"
+          },
+          "access": {
+            "landingPage": "https://www.internationalgenome.org/",
+            "authorizations": [
+              {
+                "value": "public"
+              }
+            ]
+          }
+        }
+      ],
+      "version": "1.0",
+      "description": "Chromosome Y",
+      "licenses": [
+        {
+          "name": "BY-NC-SA"
+        }
+      ],
+      "storedIn": {
+        "name": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz",
+        "description": "Gzipped .vcf file containing sequence variations"
+      },
+      "dimensions": [
+        {
+          "name": {
+            "value": "Count of Single Nucleotide Polymorphism variants"
+          },
+          "values": [
+            "60505"
+          ]
+        },
+        {
+          "name": {
+            "value": "Count of single-nucleotide insertion and deletion events"
+          },
+          "values": [
+            "1314"
+          ]
+        }
+      ],
+      "extraProperties": [
+        {
+          "category": "FTP link to gzipped FASTA file containing reference DNA sequence",
+          "values": [
+            {
+              "value": "ftp://ftp.1000genomes.ebi.ac.uk//vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+            }
+          ]
+        },
+        {
+          "category": "CONP_status",
+          "values": [
+            {
+              "value": "external"
+            }
+          ]
+        },
+        {
+          "category": "files",
+          "values": [
+            {
+              "value": "25"
+            }
+          ]
+        },
+        {
+          "category": "subjects",
+          "values": [
+            {
+              "value": "2504"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "extraProperties": [
+    {
+      "category": "contact",
+      "values": [
+        {
+          "value": "info@1000genomes.org"
+        }
+      ]
+    },
+    {
+      "category": "CONP_status",
+      "values": [
+        {
+          "value": "external"
+        }
+      ]
+    },
+    {
+      "category": "files",
+      "values": [
+        {
+          "value": "25"
+        }
+      ]
+    },
+    {
+      "category": "subjects",
+      "values": [
+        {
+          "value": "2504"
+        }
+      ]
+    },
+    {
+      "category": "logo",
+      "values": [
+        {
+          "value": "logo.png"
+        }
+      ]
+    }
+  ]
 }

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -11,6 +11,14 @@ logger = logging.getLogger(__name__)
 SCHEMA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'conp-dats', 'dataset_schema.json')
 
 
+# set value to 0 if there is no controlled vocabulary list, set value to a list if there is one.
+REQUIRED_EXTRA_PROPERTIES = {
+    "files": 0,
+    "subjects": 0,
+    "CONP_status": ["CONP", "Canadian", "external"]
+}
+
+
 def main(argv):
     FORMAT = '%(message)s'
     logging.basicConfig(format=FORMAT)
@@ -29,6 +37,7 @@ def main(argv):
     with open(json_filename) as json_file:
         json_obj = json.load(json_file)
         validate_json(json_obj)
+        validate_non_schema_required(json_obj)
 
 
 def validate_json(json_obj):
@@ -39,19 +48,80 @@ def validate_json(json_obj):
     # now validate json file
     try:
         jsonschema.validate(json_obj, json_schema, format_checker=jsonschema.FormatChecker())
-        logger.info('The file is valid. Validation passed.')
+        logger.info("JSON schema validation passed.")
         return True
     except jsonschema.exceptions.ValidationError:
         errors = [e for e in v.iter_errors((json_obj))]
-        logger.info(f"The file is not valid. Total errors: {len(errors)}")
+        logger.info(f"The file is not valid. Total json schema errors: {len(errors)}")
         for i, error in enumerate(errors, 1):
             logger.error(f"{i} Validation error in {'.'.join(str(v) for v in error.path)}: {error.message}")
-        logger.info('Validation failed.')
+        logger.info("JSON schema validation failed.")
         return False
 
 
+def validate_extra_properties(dataset):
+    """ Checks if required extraProperties are present in a dataset."""
+
+    try:
+        errors = []
+        extra_prop_categories = {prop["category"]: [value["value"] for value in prop["values"]]
+                                 for prop in dataset["extraProperties"] if "extraProperties" in dataset}
+        # first checks if required extraProperties categories are present
+        for category in REQUIRED_EXTRA_PROPERTIES:
+            if category not in extra_prop_categories:
+                error_message = f"Validation error in {dataset['title']}: " \
+                                f"extraProperties.category.{category} is required but not found."
+                errors.append(error_message)
+
+        # checks if values of required extraProperties are correct according to a controlled vocabulary
+        if "CONP_status" in extra_prop_categories:
+            for each_value in extra_prop_categories["CONP_status"]:
+                if each_value not in REQUIRED_EXTRA_PROPERTIES["CONP_status"]:
+                    error_message = f"Validation error in {dataset['title']}: extraProperties.category." \
+                                    f"CONP_status - {each_value} is not allowed value for CONP_status. " \
+                                    f"Allowed values are {REQUIRED_EXTRA_PROPERTIES['CONP_status']}."
+                    errors.append(error_message)
+
+        if errors:
+            return False, errors
+        else:
+            return True, errors
+
+    # extraProperties is only required property which is not required on dataset_schema level,
+    # if it's not present an Exception is raised
+    except KeyError as e:
+        raise Exception(f"{e} is required."
+                        f"The following extra properties categories are required: "
+                        f"{[k for k in REQUIRED_EXTRA_PROPERTIES.keys()]}")
+
+
+def validate_recursively(obj, errors):
+    """ Checks all datasets recursively for required extraProperties. """
+
+    val, errors_list = validate_extra_properties(obj)
+    errors.extend(errors_list)
+    if "hasPart" in obj:
+        for each in obj["hasPart"]:
+            validate_recursively(each, errors)
+
+
+def validate_non_schema_required(json_obj):
+    """ Checks if json object has all required extra properties beyond json schema. Prints error report. """
+
+    errors = []
+    validate_recursively(json_obj, errors)
+    if errors:
+        logger.info(f"Total required extra properties errors: {len(errors)}")
+        for i, er in enumerate(errors, 1):
+            logger.error(f"{i} {er}")
+        return False
+    else:
+        logger.info(f"Required extra properties validation passed.")
+        return True
+
+
 def help():
-    return logger.info('Usage: python validator.py --file=doc.json')
+    return logger.info("Usage: python validator.py --file=doc.json")
 
 
 if __name__ == "__main__":

--- a/tests/test_dats_validator.py
+++ b/tests/test_dats_validator.py
@@ -2,25 +2,81 @@ import unittest
 import json
 import os
 import sys
+import copy
 sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'scripts'))
-from dats_validator.validator import validate_json
+from dats_validator.validator import (validate_json,
+                                      validate_non_schema_required,
+                                      validate_extra_properties,
+                                      REQUIRED_EXTRA_PROPERTIES
+                                      )
 
 
 EXAMPLES = os.path.join(os.path.dirname(sys.path[0]), 'scripts', 'dats_validator', 'examples')
+VALID = os.path.join(EXAMPLES, 'valid_dats.json')
+INVALID = os.path.join(EXAMPLES, 'invalid_dats.json')
+
+
+with open(VALID) as v_file:
+    valid_obj = json.load(v_file)
+
+with open(INVALID) as inv_file:
+    invalid_obj = json.load(inv_file)
 
 class JsonschemaTest(unittest.TestCase):
-    valid =  os.path.join(EXAMPLES, 'valid_dats.json')
-    invalid = os.path.join(EXAMPLES, 'invalid_dats.json')
 
     def test_validate_json(self):
-        with open(self.valid) as v_file:
-            valid_obj = json.load(v_file)
-            valid_validation = validate_json(valid_obj)
-        with open(self.invalid) as inv_file:
-            invalid_obj = json.load(inv_file)
-            invalid_validation = validate_json(invalid_obj)
+        valid_validation = validate_json(valid_obj)
+        invalid_validation = validate_json(invalid_obj)
         self.assertEqual(valid_validation, True)
         self.assertEqual(invalid_validation, False)
+
+
+class ExtraPropertiesTest(unittest.TestCase):
+
+    def test_non_schema_required(self):
+        valid_validation = validate_non_schema_required(valid_obj)
+        invalid_validation = validate_non_schema_required(invalid_obj)
+        self.assertEqual(valid_validation, True)
+        self.assertEqual(invalid_validation, False)
+
+    def test_exception(self):
+        modified_copy = copy.deepcopy(valid_obj)
+        # two possible key errors are extraProperties and title (the latter since it's used in error message)
+        # introduce key error
+        del modified_copy["extraProperties"]
+        with self.assertRaises(Exception):
+            validate_non_schema_required(modified_copy)
+
+        modified_copy_2 = copy.deepcopy(valid_obj)
+        for child in modified_copy_2["hasPart"]:
+            # KeyError on 'title' will only be raised if there is an error in extraProperties
+            del child["title"]
+            del child["extraProperties"][1]
+        with self.assertRaises(Exception):
+            validate_non_schema_required(modified_copy_2)
+
+    def test_conp_status_values(self):
+        modified_copy = copy.deepcopy(valid_obj)
+        for prop in modified_copy["extraProperties"]:
+            if prop["category"] == "CONP_status":
+                prop["values"] = [
+                    {"value": "conp"},
+                    {"value": "External"},
+                    {"value": "random"},
+                    {"value": "canadian"}
+                ]
+        invalid_validation, errors = validate_extra_properties(modified_copy)
+        for error in errors:
+            self.assertIn(f"Allowed values are {REQUIRED_EXTRA_PROPERTIES['CONP_status']}", error)
+
+    def test_subject(self):
+        modified_copy = copy.deepcopy(valid_obj)
+        for prop in modified_copy["extraProperties"]:
+            if prop["category"] in REQUIRED_EXTRA_PROPERTIES.keys():
+                del prop
+        invalid_validation, errors = validate_extra_properties(modified_copy)
+        for error in errors:
+            self.assertIn(f"required but not found", error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Addresses issue #345 

- Validates that `extraProperties` contains categories `subjects`, `files ` and `CONP_status` in dataset and all nested datasets
- Validates that `CONP_status` values are `CONP`, `Canadian`, `external`


Now the validation will be split into two parts:
1. Validates DATS.json against dataset_schema.json
2. Validates if all required extra properties are present in DATS.json and have valid values (according to this: https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_DATS_fields.md)

Whenever the controlled vocabulary (e.g. for CONP_status) changed, or new required `extraProperties` are added, these changes should go to REQUIRED_EXTRA_PROPERTIES.


@glatard @joeyzhou98 Could you please add `validate_non_schema_required` to tests, the same as it was done with `validate_json` previously. Thanks!
