### PR TITLE
Added CHBMP as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,3 +115,6 @@
 [submodule "projects/cneuromod"]
 	path = projects/cneuromod
 	url = https://github.com/glatard/cneuromod.git
+[submodule "projects/CHBMP"]
+	path = projects/CHBMP
+	url = https://github.com/conpdatasets/CHBMP.git


### PR DESCRIPTION
## Description

This adds the Cuban Human Brain Mapping Project (CHBMP) to the CONP super dataset.

Note: the subproject CHBMP has no data yet in the repository, just descriptions of the dataset

## Checklist

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [x] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [ ] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
