### PR TITLE
Add Braincode Mouse Image dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,3 +115,8 @@
 [submodule "projects/cneuromod"]
 	path = projects/cneuromod
 	url = https://github.com/glatard/cneuromod.git
+[submodule "projects/braincode_Mouse_Image"]
+	path = projects/braincode_Mouse_Image
+	url = ./projects/braincode_Mouse_Image
+	branch = master
+	datalad-id = 0bfe4696-d12e-11ea-9db8-080027a96228

--- a/.gitmodules
+++ b/.gitmodules
@@ -117,6 +117,4 @@
 	url = https://github.com/glatard/cneuromod.git
 [submodule "projects/braincode_Mouse_Image"]
 	path = projects/braincode_Mouse_Image
-	url = ./projects/braincode_Mouse_Image
-	branch = master
-	datalad-id = 0bfe4696-d12e-11ea-9db8-080027a96228
+	url = https://github.com/conpdatasets/braincode_Mouse_Image.git


### PR DESCRIPTION
## Description
Add Braincode **Mouse Image** dataset. This is the first out of three main datasets from OBI.
Contains 26 children datasets in `hasPart`.


## Checklist
<!--- Task to do for an approval of the pull request -->

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [x] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
#353 
