### PR TITLE
Add Braincode fBIRN dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,3 +121,8 @@
 [submodule "projects/braincode_Mouse_Image"]
 	path = projects/braincode_Mouse_Image
 	url = https://github.com/conpdatasets/braincode_Mouse_Image.git
+[submodule "projects/braincode_fBIRN"]
+	path = projects/braincode_fBIRN
+	url = ./projects/braincode_fBIRN
+	branch = add-braincode-fbirn
+	datalad-id = 05e981a6-dbe4-11ea-9fd2-080027a96228

--- a/.gitmodules
+++ b/.gitmodules
@@ -123,6 +123,4 @@
 	url = https://github.com/conpdatasets/braincode_Mouse_Image.git
 [submodule "projects/braincode_fBIRN"]
 	path = projects/braincode_fBIRN
-	url = ./projects/braincode_fBIRN
-	branch = add-braincode-fbirn
-	datalad-id = 05e981a6-dbe4-11ea-9fd2-080027a96228
+	url = https://github.com/conpdatasets/braincode_fBIRN.git


### PR DESCRIPTION
## Description
Add Braincode fBIRN Image dataset. This is the second out of three main datasets from OBI.
Contains 13 children datasets in `hasPart`.

## Checklist
<!--- Task to do for an approval of the pull request -->

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [x] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
#353
