### PR TITLE
Added crawler requirements.txt file

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+git-python==1.0.3
+datalad==0.13.3
+html2markdown==0.1.7


### PR DESCRIPTION
## Description

This adds a `requirements.txt` file for the crawler pipeline. 

Once merged, users will only need to execute `pip install -r requirements.txt` to get all the requirements installed before running the crawler.