### PR TITLE
Create additional summary scripts

### DIFF
--- a/scripts/data_aggregation_summary_scripts/create_dataset_statistcs_per_data_providers.py
+++ b/scripts/data_aggregation_summary_scripts/create_dataset_statistcs_per_data_providers.py
@@ -35,7 +35,7 @@ def main(argv):
         csv_content.append(summary_list)
 
     # write the summary statistics into a CSV file
-    Utility.write_csv_file('summary_statistics_per_data_providers', csv_content)
+    Utility.write_csv_file('dataset_summary_statistics_per_data_providers', csv_content)
 
 
 def parse_input(argv):
@@ -160,48 +160,21 @@ def get_stats_for_data_provider(dataset_summary_dict, data_provider):
         else:
             total_files += dataset_dict['number_of_files']
 
-        print(dataset_dict['title'])
-        print(dataset_dict['data_provider'])
-        print('\n')
-
         if dataset_dict['authorization'].lower() in ['private', 'restricted']:
             requires_login += 1
 
         if dataset_dict['size_unit'].lower() == 'b':
             total_size += dataset_dict['dataset_size'] / pow(1024, 3)
-            print('kb')
-            print(dataset_dict['dataset_size'])
-            print(dataset_dict['dataset_size'] / pow(1024, 2))
-            print('\n')
         elif dataset_dict['size_unit'].lower() == 'kb':
             total_size += dataset_dict['dataset_size'] / pow(1024, 2)
-            print('kb')
-            print(dataset_dict['dataset_size'])
-            print(dataset_dict['dataset_size'] / pow(1024, 2))
-            print('\n')
         elif dataset_dict['size_unit'].lower() == 'mb':
             total_size += dataset_dict['dataset_size'] / 1024
-            print('mb')
-            print(dataset_dict['dataset_size'])
-            print(dataset_dict['dataset_size'] / 1024)
-            print('\n')
         elif dataset_dict['size_unit'].lower() == 'gb':
             total_size += dataset_dict['dataset_size']
-            print('gb')
-            print(dataset_dict['dataset_size'])
-            print('\n')
         elif dataset_dict['size_unit'].lower() == 'tb':
             total_size += dataset_dict['dataset_size'] * 1024
-            print('tb')
-            print(dataset_dict['dataset_size'])
-            print(dataset_dict['dataset_size'] / 1024)
-            print('\n')
         elif dataset_dict['size_unit'].lower() == 'pb':
             total_size += dataset_dict['dataset_size'] * pow(1024, 2)
-            print('pb')
-            print(dataset_dict['dataset_size'])
-            print(dataset_dict['dataset_size'] / 1024)
-            print('\n')
 
         for keyword in dataset_dict['keywords']:
             if keyword not in keywords_list:

--- a/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
+++ b/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
@@ -23,7 +23,6 @@ def main(argv):
             'Number Of Datasets Requiring Authentication',
             'Total Number Of Files',
             'Total Size (GB)',
-            'CONP Status',
             'Keywords Describing The Data'
         ]
     ]
@@ -100,7 +99,6 @@ def parse_dats_information(dats_dict):
         'dataset_size'   : dats_dict['distributions'][0]['size'],
         'size_unit'      : dats_dict['distributions'][0]['unit']['value'],
         'number_of_files': values_dict['files']        if 'files'       in values_dict else '',
-        'conp_status'    : values_dict['CONP_status']  if 'CONP_status' in values_dict else '',
         'keywords'       : values_dict['keywords']     if 'keywords'    in values_dict else '',
     }
 
@@ -111,9 +109,6 @@ def get_stats_for_data_provider(dataset_summary_dict, data_provider):
     requires_login  = 0
     total_size      = 0
     total_files     = 0
-    total_conp_data = 0
-    total_canadian  = 0
-    total_external  = 0
     keywords_list   = []
 
     for index in dataset_summary_dict:
@@ -128,28 +123,48 @@ def get_stats_for_data_provider(dataset_summary_dict, data_provider):
         else:
             total_files += dataset_dict['number_of_files']
 
-        print(dataset_dict['authorization'])
+        print(dataset_dict['title'])
+        print(dataset_dict['data_provider'])
+        print('\n')
 
-        if dataset_dict['authorization'] in ['private', 'restricted']:
+        if dataset_dict['authorization'].lower() in ['private', 'restricted']:
             requires_login += 1
 
-        if dataset_dict['size_unit'] == 'KB':
-            total_size += dataset_dict['dataset_size'] * pow(1024, 2)
-        elif dataset_dict['size_unit'] == 'MB':
-            total_size += dataset_dict['dataset_size'] * 1024
-        elif dataset_dict['size_unit'] == 'GB':
-            total_size += dataset_dict['dataset_size']
-        elif dataset_dict['size_unit'] == 'TB':
-            total_size += dataset_dict['dataset_size'] / 1024
-        elif dataset_dict['size_unit'] == 'PB':
+        if dataset_dict['size_unit'].lower() == 'b':
+            total_size += dataset_dict['dataset_size'] / pow(1024, 3)
+            print('kb')
+            print(dataset_dict['dataset_size'])
+            print(dataset_dict['dataset_size'] / pow(1024, 2))
+            print('\n')
+        elif dataset_dict['size_unit'].lower() == 'kb':
             total_size += dataset_dict['dataset_size'] / pow(1024, 2)
-
-        if dataset_dict['conp_status'] == 'CONP':
-            total_conp_data += 1
-        elif dataset_dict['conp_status'] == 'Canadian':
-            total_canadian += 1
-        elif dataset_dict['conp_status'] == 'external':
-            total_external += 1
+            print('kb')
+            print(dataset_dict['dataset_size'])
+            print(dataset_dict['dataset_size'] / pow(1024, 2))
+            print('\n')
+        elif dataset_dict['size_unit'].lower() == 'mb':
+            total_size += dataset_dict['dataset_size'] / 1024
+            print('mb')
+            print(dataset_dict['dataset_size'])
+            print(dataset_dict['dataset_size'] / 1024)
+            print('\n')
+        elif dataset_dict['size_unit'].lower() == 'gb':
+            total_size += dataset_dict['dataset_size']
+            print('gb')
+            print(dataset_dict['dataset_size'])
+            print('\n')
+        elif dataset_dict['size_unit'].lower() == 'tb':
+            total_size += dataset_dict['dataset_size'] * 1024
+            print('tb')
+            print(dataset_dict['dataset_size'])
+            print(dataset_dict['dataset_size'] / 1024)
+            print('\n')
+        elif dataset_dict['size_unit'].lower() == 'pb':
+            total_size += dataset_dict['dataset_size'] * pow(1024, 2)
+            print('pb')
+            print(dataset_dict['dataset_size'])
+            print(dataset_dict['dataset_size'] / 1024)
+            print('\n')
 
         for keyword in dataset_dict['keywords']:
             if keyword not in keywords_list:
@@ -157,17 +172,12 @@ def get_stats_for_data_provider(dataset_summary_dict, data_provider):
                     continue
                 keywords_list.append(keyword)
 
-    conp_status_summary = 'CONP (' + str(total_conp_data) + '); ' \
-                          'Canadian (' + str(total_canadian) + '); ' \
-                          'External (' + str(total_external) + ')'
-
     return [
         data_provider,
         str(dataset_number),
         str(requires_login),
         str(total_files),
-        str(total_size),
-        conp_status_summary,
+        str(round(total_size)),
         ', '.join(keywords_list)
     ]
 

--- a/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
+++ b/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
@@ -6,16 +6,20 @@ import lib.Utility as Utility
 
 def main(argv):
 
+    # create the getopt table + read and validate the options given to the script
     conp_dataset_dir = parse_input(argv)
 
+    # read the content of the DATS.json files present in the conp-dataset directory
     dataset_descriptor_list = Utility.read_conp_dataset_dir(conp_dataset_dir)
 
+    # digest the content of the DATS.json files into a summary of variables of interest
     datasets_summary_dict = {}
     i = 0
     for dataset in dataset_descriptor_list:
         datasets_summary_dict[i] = parse_dats_information(dataset)
         i += 1
 
+    # create the summary statistics of the variables of interest organized per data providers
     csv_content = [
         [
             'Data Provider',
@@ -30,12 +34,22 @@ def main(argv):
         summary_list = get_stats_for_data_provider(datasets_summary_dict, data_provider)
         csv_content.append(summary_list)
 
+    # write the summary statistics into a CSV file
     Utility.write_csv_file('summary_statistics_per_data_providers', csv_content)
 
 
 def parse_input(argv):
+    """
+    Creates the GetOpt table + read and validate the options given when calling the script.
 
-    conp_dataset_dir = None
+    :param argv: command-line arguments
+     :type argv: list
+
+    :return: the path to the conp-dataset directory
+     :rtype: str
+    """
+
+    conp_dataset_dir_path = None
 
     description = '\nThis tool facilitates the creation of statistics per data providers for reporting purposes.' \
                   ' It will read DATS files and print out a summary per data providers based on the following list' \
@@ -59,22 +73,33 @@ def parse_input(argv):
             print(description + usage)
             sys.exit()
         elif opt == '-d':
-            conp_dataset_dir = arg
+            conp_dataset_dir_path = arg
 
-    if not conp_dataset_dir:
+    if not conp_dataset_dir_path:
         print('a path to the conp-dataset needs to be given as an argument to the script by using the option `-d`')
         print(description + usage)
         sys.exit()
 
-    if not os.path.exists(conp_dataset_dir + '/projects'):
-        print(conp_dataset_dir + 'does not appear to be a valid path and does not include a `projects` directory')
+    if not os.path.exists(conp_dataset_dir_path + '/projects'):
+        print(conp_dataset_dir_path + 'does not appear to be a valid path and does not include a `projects` directory')
         print(description + usage)
         sys.exit()
 
-    return conp_dataset_dir
+    return conp_dataset_dir_path
 
 
 def parse_dats_information(dats_dict):
+    """
+    Parse the content of the DATS dictionary and grep the variables of interest for
+    the summary statistics.
+
+    :param dats_dict: dictionary with the content of a dataset's DATS.json file
+     :type dats_dict: dict
+
+    :return: dictionary with the variables of interest to use to produce the
+             summary statistics
+     :rtype: dict
+    """
 
     extra_properties = dats_dict['extraProperties']
     keywords = dats_dict['keywords']
@@ -104,6 +129,18 @@ def parse_dats_information(dats_dict):
 
 
 def get_stats_for_data_provider(dataset_summary_dict, data_provider):
+    """
+    Produces a summary statistics per data provider (Zenodo, OSF, LORIS...) of the
+    identified variables of interest.
+
+    :param dataset_summary_dict: dictionary with the variables of interest for the summary
+     :type dataset_summary_dict: dict
+    :param data_provider       : name of the data provider
+     :type data_provider       : str
+
+    :return: list with the summary statistics on the variables for the data provider
+     :rtype: list
+    """
 
     dataset_number  = 0
     requires_login  = 0

--- a/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
+++ b/scripts/data_aggregation_summary_scripts/create_statistcs_per_data_providers.py
@@ -1,0 +1,176 @@
+import getopt
+import sys
+import os
+import lib.Utility as Utility
+
+
+def main(argv):
+
+    conp_dataset_dir = parse_input(argv)
+
+    dataset_descriptor_list = Utility.read_conp_dataset_dir(conp_dataset_dir)
+
+    datasets_summary_dict = {}
+    i = 0
+    for dataset in dataset_descriptor_list:
+        datasets_summary_dict[i] = parse_dats_information(dataset)
+        i += 1
+
+    csv_content = [
+        [
+            'Data Provider',
+            'Number Of Datasets',
+            'Number Of Datasets Requiring Authentication',
+            'Total Number Of Files',
+            'Total Size (GB)',
+            'CONP Status',
+            'Keywords Describing The Data'
+        ]
+    ]
+    for data_provider in ['braincode', 'frdr', 'loris', 'osf', 'zenodo']:
+        summary_list = get_stats_for_data_provider(datasets_summary_dict, data_provider)
+        csv_content.append(summary_list)
+
+    Utility.write_csv_file('summary_statistics_per_data_providers', csv_content)
+
+
+def parse_input(argv):
+
+    conp_dataset_dir = None
+
+    description = '\nThis tool facilitates the creation of statistics per data providers for reporting purposes.' \
+                  ' It will read DATS files and print out a summary per data providers based on the following list' \
+                  'of DATS fields present in the DATS. json of every dataset present in the conp-dataset/projects' \
+                  'directory.\n Queried fields: <distribution->access->landingPage>; <distributions->access->authorizations>; ' \
+                  '<distributions->size>; <extraProperties->files>; <keywords>\n'
+    usage = (
+        '\n'
+        'usage  : python ' + __file__ + ' -d <conp-dataset directory path>\n\n'
+        'options: \n'
+            '\t-d: path to the conp-dataset directory to parse\n'
+    )
+
+    try:
+        opts, args = getopt.getopt(argv, "hd:")
+    except getopt.GetoptError:
+        sys.exit()
+
+    for opt, arg in opts:
+        if opt == '-h':
+            print(description + usage)
+            sys.exit()
+        elif opt == '-d':
+            conp_dataset_dir = arg
+
+    if not conp_dataset_dir:
+        print('a path to the conp-dataset needs to be given as an argument to the script by using the option `-d`')
+        print(description + usage)
+        sys.exit()
+
+    if not os.path.exists(conp_dataset_dir + '/projects'):
+        print(conp_dataset_dir + 'does not appear to be a valid path and does not include a `projects` directory')
+        print(description + usage)
+        sys.exit()
+
+    return conp_dataset_dir
+
+
+def parse_dats_information(dats_dict):
+
+    extra_properties = dats_dict['extraProperties']
+    keywords = dats_dict['keywords']
+
+    values_dict = {
+        'extraProperties': {},
+        'keywords': []
+    }
+    for extra_property in extra_properties:
+        values_dict[extra_property['category']] = extra_property['values'][0]['value']
+    for keyword in keywords:
+        values_dict['keywords'].append(keyword['value'])
+
+    authorization = 'unknown'
+    if 'authorizations' in dats_dict['distributions'][0]['access']:
+        authorization = dats_dict['distributions'][0]['access']['authorizations'][0]['value']
+
+    return {
+        'title'          : dats_dict['title'],
+        'data_provider'  : dats_dict['distributions'][0]['access']['landingPage'],
+        'authorization'  : authorization,
+        'dataset_size'   : dats_dict['distributions'][0]['size'],
+        'size_unit'      : dats_dict['distributions'][0]['unit']['value'],
+        'number_of_files': values_dict['files']        if 'files'       in values_dict else '',
+        'conp_status'    : values_dict['CONP_status']  if 'CONP_status' in values_dict else '',
+        'keywords'       : values_dict['keywords']     if 'keywords'    in values_dict else '',
+    }
+
+
+def get_stats_for_data_provider(dataset_summary_dict, data_provider):
+
+    dataset_number  = 0
+    requires_login  = 0
+    total_size      = 0
+    total_files     = 0
+    total_conp_data = 0
+    total_canadian  = 0
+    total_external  = 0
+    keywords_list   = []
+
+    for index in dataset_summary_dict:
+
+        dataset_dict = dataset_summary_dict[index]
+        if data_provider not in dataset_dict['data_provider']:
+            continue
+
+        dataset_number += 1
+        if isinstance(dataset_dict['number_of_files'], str):
+            total_files += int(dataset_dict['number_of_files'].replace(',', ''))
+        else:
+            total_files += dataset_dict['number_of_files']
+
+        print(dataset_dict['authorization'])
+
+        if dataset_dict['authorization'] in ['private', 'restricted']:
+            requires_login += 1
+
+        if dataset_dict['size_unit'] == 'KB':
+            total_size += dataset_dict['dataset_size'] * pow(1024, 2)
+        elif dataset_dict['size_unit'] == 'MB':
+            total_size += dataset_dict['dataset_size'] * 1024
+        elif dataset_dict['size_unit'] == 'GB':
+            total_size += dataset_dict['dataset_size']
+        elif dataset_dict['size_unit'] == 'TB':
+            total_size += dataset_dict['dataset_size'] / 1024
+        elif dataset_dict['size_unit'] == 'PB':
+            total_size += dataset_dict['dataset_size'] / pow(1024, 2)
+
+        if dataset_dict['conp_status'] == 'CONP':
+            total_conp_data += 1
+        elif dataset_dict['conp_status'] == 'Canadian':
+            total_canadian += 1
+        elif dataset_dict['conp_status'] == 'external':
+            total_external += 1
+
+        for keyword in dataset_dict['keywords']:
+            if keyword not in keywords_list:
+                if keyword == 'canadian-open-neuroscience-platform':
+                    continue
+                keywords_list.append(keyword)
+
+    conp_status_summary = 'CONP (' + str(total_conp_data) + '); ' \
+                          'Canadian (' + str(total_canadian) + '); ' \
+                          'External (' + str(total_external) + ')'
+
+    return [
+        data_provider,
+        str(dataset_number),
+        str(requires_login),
+        str(total_files),
+        str(total_size),
+        conp_status_summary,
+        ', '.join(keywords_list)
+    ]
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/data_aggregation_summary_scripts/create_tools_statistics_per_domain.py
+++ b/scripts/data_aggregation_summary_scripts/create_tools_statistics_per_domain.py
@@ -1,0 +1,179 @@
+import getopt
+import sys
+import os
+import lib.Utility as Utility
+
+
+def main(argv):
+
+    # create the getopt table + read and validate the options given to the script
+    tools_json_dir_path = parse_input(argv)
+
+    # read the content of the DATS.json files present in the boutiques's cached
+    # directory present in ~
+    tool_descriptor_list = Utility.read_boutiques_cached_dir(tools_json_dir_path)
+
+    # digest the content of the DATS.json files into a summary of variables of interest
+    tools_summary_dict = {}
+    i = 0
+    for tool in tool_descriptor_list:
+        tools_summary_dict[i] = parse_json_information(tool)
+        i += 1
+
+    # create the summary statistics of the variables of interest organized per
+    # domain of application
+    csv_content = [
+        [
+            'Domain of Application',
+            'Number Of Tools',
+            'Containers',
+            'Execution Capacity'
+        ]
+    ]
+    for field in ['Neuroinformatics', 'Bioinformatics', 'MRI', 'EEG', 'Connectome', 'BIDS-App']:
+        summary_list = get_stats_per_domain(tools_summary_dict, field)
+        csv_content.append(summary_list)
+
+    # write the summary statistics into a CSV file
+    Utility.write_csv_file('tools_summary_statistics_per_domain', csv_content)
+
+
+def parse_input(argv):
+    """
+    Creates the GetOpt table + read and validate the options given when calling the script.
+
+    :param argv: command-line arguments
+     :type argv: list
+
+    :return: the path to the tools directory containing the Boutiques JSON descriptors
+             (typically ~/.cache/boutiques/production)
+     :rtype: str
+    """
+
+    tools_dir_path = None
+
+    description = '\nThis tool facilitates the creation of tools summary statistics per domain of application for reporting purposes.' \
+                  ' It will read Boutiques\'s JSON files and print out a summary per domain based on the following list of tags:' \
+                  '\nNeuroinformatics, Bioinformatics, MRI, EEG, Connectome, BIDS-App.\n'
+    usage = (
+        '\n'
+        'usage  : python ' + __file__ + ' -d <path to the Boutiques\'s JSON cached directory to parse.'
+            ' (typically ~/.cache/boutiques/production>\n\n'
+        'options: \n'
+            '\t-d: path to the Boutiques\'s JSON cached directory to parse.'
+            ' (typically ~/.cache/boutiques/production>\n\n'
+    )
+
+    try:
+        opts, args = getopt.getopt(argv, "hd:")
+    except getopt.GetoptError:
+        sys.exit()
+
+    for opt, arg in opts:
+        if opt == '-h':
+            print(description + usage)
+            sys.exit()
+        elif opt == '-d':
+            tools_dir_path = arg
+
+    if not tools_dir_path:
+        print('a path to the Boutiques\'s JSON cached directory needs to be given as an argument to the script by using the option `-d`')
+        print(description + usage)
+        sys.exit()
+
+    if not os.path.exists(tools_dir_path):
+        print(tools_dir_path + 'does not appear to be a valid path')
+        print(description + usage)
+        sys.exit()
+
+    return tools_dir_path
+
+
+def parse_json_information(json_dict):
+    """
+    Parse the content of the JSON dictionary and grep the variables of interest for
+    the summary statistics.
+
+    :param json_dict: dictionary with the content of a tool JSON descriptor file
+     :type json_dict: dict
+
+    :return: dictionary with the variables of interest to use to produce the
+             summary statistics
+     :rtype: dict
+    """
+
+    tool_summary_dict = {
+        'title'         : json_dict['name'],
+        'container_type': None,
+        'domain'        : None,
+        'online_platform_urls': None
+    }
+
+    if 'container-image' in json_dict and 'type' in json_dict['container-image']:
+        tool_summary_dict['container_type'] = json_dict['container-image']['type']
+
+    if 'tags' in json_dict and 'domain' in json_dict['tags']:
+        tool_summary_dict['domain'] = [ x.lower() for x in json_dict['tags']['domain']]
+
+    if 'online-platform-urls' in json_dict:
+        tool_summary_dict['online_platform_urls'] = json_dict['online-platform-urls']
+
+    return tool_summary_dict
+
+
+def get_stats_per_domain(tool_summary_dict, domain):
+    """
+    Produces a summary statistics per domain (Neuroinformatics, Bioinformatics, MRI, EEG...)
+    of the identified variables of interest.
+
+    :param tool_summary_dict: dictionary with the variables of interest for the summary
+     :type tool_summary_dict: dict
+    :param domain           : name of the domain of application
+     :type domain           : str
+
+    :return: list with the summary statistics on the variables for the domain of application
+     :rtype: list
+    """
+
+    container = {
+        'docker'     : 0,
+        'singularity': 0
+    }
+    number_of_tools        = 0
+    number_of_cbrain_tools = 0
+
+    for index in tool_summary_dict:
+
+        tool_dict = tool_summary_dict[index]
+
+        if not tool_dict['domain']:
+            continue
+
+        if domain.lower() not in tool_dict['domain'] and domain != 'BIDS-App':
+            continue
+
+        if domain == 'BIDS-App' and 'bids app' not in tool_dict['title'].lower():
+            continue
+
+        number_of_tools += 1
+
+        if tool_dict['container_type'] == 'docker':
+            container['docker'] += 1
+        elif tool_dict['container_type'] == 'singularity':
+            container['singularity'] += 1
+
+        print(tool_dict['online_platform_urls'])
+
+        if tool_dict['online_platform_urls'] and 'https://portal.cbrain.mcgill.ca' in tool_dict['online_platform_urls']:
+            number_of_cbrain_tools += 1
+
+    return [
+        domain,
+        str(number_of_tools),
+        'Docker (' + str(container['docker']) + '); Singularity (' + str(container['singularity']) + ')',
+        'CBRAIN (' + str(number_of_cbrain_tools) + ')'
+    ]
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/data_aggregation_summary_scripts/lib/Utility.py
+++ b/scripts/data_aggregation_summary_scripts/lib/Utility.py
@@ -1,0 +1,53 @@
+import os
+import json
+import csv
+import datetime
+
+
+def read_conp_dataset_dir(conp_dataset_dir):
+
+    dataset_dirs_list = os.listdir(conp_dataset_dir + '/projects')
+
+    dataset_descriptor_list =[]
+
+    for dataset in dataset_dirs_list:
+        if dataset == '.touchfile':
+            continue
+
+        dats_path = conp_dataset_dir + '/projects/' + dataset + '/DATS.json'
+        if not (os.path.exists(dats_path)):
+            subdataset_content_list = look_for_dats_file_in_subdataset_folders(conp_dataset_dir, dataset)
+            dataset_descriptor_list.extend(subdataset_content_list)
+            continue
+
+        print('Reading file: ' + dats_path)
+        with open(dats_path) as dats_file:
+            dats_dict = json.loads(dats_file.read())
+            dataset_descriptor_list.append(dats_dict)
+
+    return dataset_descriptor_list
+
+
+def look_for_dats_file_in_subdataset_folders(conp_dataset_dir, dataset):
+
+    subdataset_dirs_list = os.listdir(conp_dataset_dir + '/projects/' + dataset)
+
+    subdataset_content = []
+
+    for subdataset in subdataset_dirs_list:
+        dats_path = conp_dataset_dir + '/projects/' + dataset + '/' + subdataset + '/DATS.json'
+        print('Reading file: ' + dats_path)
+        with open(dats_path) as dats_file:
+            dats_dict = json.loads(dats_file.read())
+            subdataset_content.append(dats_dict)
+
+    return subdataset_content
+
+
+def write_csv_file(csv_file_basename, csv_content):
+
+    csv_file = os.getcwd() + '/' + csv_file_basename + '_' + str(datetime.date.today()) + '.csv'
+
+    with open(csv_file, 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerows(csv_content)

--- a/scripts/data_aggregation_summary_scripts/lib/Utility.py
+++ b/scripts/data_aggregation_summary_scripts/lib/Utility.py
@@ -4,9 +4,21 @@ import csv
 import datetime
 
 
-def read_conp_dataset_dir(conp_dataset_dir):
+def read_conp_dataset_dir(conp_dataset_dir_path):
+    """
+    Reads the conp-dataset projects directory and return the contents
+    of every dataset DATS.json file in a list (one list item = one
+    dataset DATS.json content).
 
-    dataset_dirs_list = os.listdir(conp_dataset_dir + '/projects')
+    :param conp_dataset_dir_path: path to the conp-dataset directory
+     :type conp_dataset_dir_path: str
+
+    :return: list of dictionaries with datasets' DATS.json content
+             (one list item = one dataset DATS.json content)
+     :rtype: list
+    """
+
+    dataset_dirs_list = os.listdir(conp_dataset_dir_path + '/projects')
 
     dataset_descriptor_list =[]
 
@@ -14,9 +26,9 @@ def read_conp_dataset_dir(conp_dataset_dir):
         if dataset == '.touchfile':
             continue
 
-        dats_path = conp_dataset_dir + '/projects/' + dataset + '/DATS.json'
+        dats_path = conp_dataset_dir_path + '/projects/' + dataset + '/DATS.json'
         if not (os.path.exists(dats_path)):
-            subdataset_content_list = look_for_dats_file_in_subdataset_folders(conp_dataset_dir, dataset)
+            subdataset_content_list = read_dats_file_from_subdataset_folders(conp_dataset_dir_path, dataset)
             dataset_descriptor_list.extend(subdataset_content_list)
             continue
 
@@ -28,14 +40,26 @@ def read_conp_dataset_dir(conp_dataset_dir):
     return dataset_descriptor_list
 
 
-def look_for_dats_file_in_subdataset_folders(conp_dataset_dir, dataset):
+def read_dats_file_from_subdataset_folders(conp_dataset_dir_path, dataset_name):
+    """
+    Reads DATS.json files present in the subdataset folder of a dataset_name.
 
-    subdataset_dirs_list = os.listdir(conp_dataset_dir + '/projects/' + dataset)
+    :param conp_dataset_dir_path: path to the conp-dataset_name directory
+     :type conp_dataset_dir_path: str
+    :param dataset_name         : name of the dataset to look for subdataset's DATS.json files
+     :type dataset_name         : str
+
+    :return: list of dictionaries with subdatasets' DATS.json content
+             (one list item = one subdataset DATS.json content)
+     :rtype: list
+    """
+
+    subdataset_dirs_list = os.listdir(conp_dataset_dir_path + '/projects/' + dataset_name)
 
     subdataset_content = []
 
     for subdataset in subdataset_dirs_list:
-        dats_path = conp_dataset_dir + '/projects/' + dataset + '/' + subdataset + '/DATS.json'
+        dats_path = conp_dataset_dir_path + '/projects/' + dataset_name + '/' + subdataset + '/DATS.json'
         print('Reading file: ' + dats_path)
         with open(dats_path) as dats_file:
             dats_dict = json.loads(dats_file.read())
@@ -45,6 +69,19 @@ def look_for_dats_file_in_subdataset_folders(conp_dataset_dir, dataset):
 
 
 def write_csv_file(csv_file_basename, csv_content):
+    """
+    Write the content of a list of list into a CSV file. Example of csv_content:
+        [
+            ['Header_1', 'Header_2', 'Header_3' ...],
+            ['Value_1',  'Value_2',  'Value_3'  ...],
+            ....
+        ]
+
+    :param csv_file_basename: base name that should be given to the CSV
+     :type csv_file_basename: str
+    :param csv_content      : list of list with the content of the future CSV file
+     :type csv_content      : list
+    """
 
     csv_file = os.getcwd() + '/' + csv_file_basename + '_' + str(datetime.date.today()) + '.csv'
 

--- a/scripts/data_aggregation_summary_scripts/lib/Utility.py
+++ b/scripts/data_aggregation_summary_scripts/lib/Utility.py
@@ -68,6 +68,34 @@ def read_dats_file_from_subdataset_folders(conp_dataset_dir_path, dataset_name):
     return subdataset_content
 
 
+def read_boutiques_cached_dir(tools_json_dir_path):
+    """
+    Reads the Boutiques' cache directory and return the contents
+    of every JSON descriptor file in a list (one list item = one
+    Boutiques' JSON descriptor content).
+
+    :param tools_json_dir_path: path to the cached Boutiques directory
+     :type tools_json_dir_path: str
+
+    :return: list of dictionaries with Boutiques' JSON descriptor content
+             (one list item = one Boutiques' JSON descriptor content)
+     :rtype: list
+    """
+
+    boutiques_descriptor_list = []
+
+    for json_file in os.listdir(tools_json_dir_path):
+        print(json_file)
+        if 'zenodo' not in json_file or 'swp' in json_file:
+            continue
+        json_path = tools_json_dir_path + '/' + json_file
+        with open(json_path) as json_file:
+            json_dict = json.loads(json_file.read())
+            boutiques_descriptor_list.append(json_dict)
+
+    return boutiques_descriptor_list
+
+
 def write_csv_file(csv_file_basename, csv_content):
     """
     Write the content of a list of list into a CSV file. Example of csv_content:

--- a/scripts/data_aggregation_summary_scripts/lib/__init__.py
+++ b/scripts/data_aggregation_summary_scripts/lib/__init__.py
@@ -1,0 +1,9 @@
+"""
+From the documentation at https://docs.python.org/2/tutorial/modules.html#packages
+The __init__.py files are required to make Python treat the directories as
+containing packages; this is done to prevent directories with a common name,
+such as string, from unintentionally hiding valid modules that occur later on
+the module search path. In the simplest case, __init__.py can just be an empty
+file, but it can also execute initialization code for the package or set the
+__all__ variable, described later.
+"""


### PR DESCRIPTION
## Description

This adds a new set of tools to automatically create summary for reporting. These tools return CSV files.

- `create_dataset_statistics_per_data_providers.py`: creates summary statistics (number of datasets, number of files, dataset keywords, dataset size) per data provider (Zenodo, OSF, LORIS, BrainCode...).
- `create_tools_statistics_per_domain.py`: creates a summary statistics (number of tools, containers, execution capacity) per domain of application (neuroinformatics, bioinformatics, MRI, EEG, Connectome, BIDS-App...)

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
