### PR TITLE
Make the conp-dataset PATH configurable for the crawlers

### DIFF
--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -4,10 +4,6 @@ import argparse
 import os
 import sys
 import traceback
-sys.path.append(os.path.abspath(os.path.join(os.path.expanduser("~"), "conp-dataset")))
-sys.path.append(os.path.join("/data", "crawler", "conp-dataset"))
-from scripts.Crawlers.ZenodoCrawler import ZenodoCrawler
-from scripts.Crawlers.OSFCrawler import OSFCrawler
 
 
 def parse_args():
@@ -43,6 +39,20 @@ def parse_args():
 
     with open(config_path, "r") as f:
         config = json.load(f)
+
+    if 'conp-dataset_path' not in config.keys():
+        raise Exception(
+            '"conp-dataset_path" not configured in ' + config_path + ','
+            'please configure it as follows: \n'
+            '  "conp-dataset_path": "PATH TO conp-dataset DIRECTORY",'
+        )
+
+    # import the crawler packages
+    sys.path.append(config['conp-dataset_path'])
+    global ZenodoCrawler
+    global OSFCrawler
+    from scripts.Crawlers.ZenodoCrawler import ZenodoCrawler
+    from scripts.Crawlers.OSFCrawler import OSFCrawler
 
     if not github_token and "github_token" not in config.keys():
         raise Exception(

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -47,13 +47,6 @@ def parse_args():
             '  "conp-dataset_path": "PATH TO conp-dataset DIRECTORY",'
         )
 
-    # import the crawler packages
-    sys.path.append(config['conp-dataset_path'])
-    global ZenodoCrawler
-    global OSFCrawler
-    from scripts.Crawlers.ZenodoCrawler import ZenodoCrawler
-    from scripts.Crawlers.OSFCrawler import OSFCrawler
-
     if not github_token and "github_token" not in config.keys():
         raise Exception(
             "Github token not passed by command line argument "
@@ -68,21 +61,27 @@ def parse_args():
     else:  # Retrieve github token from config file
         github_token = config["github_token"]
 
-    return github_token, config_path, args.verbose, args.force
+    return github_token, config_path, args.verbose, args.force, config['conp-dataset_path']
 
 
 if __name__ == "__main__":
-    github_token, config_path, verbose, force = parse_args()
+    github_token, config_path, verbose, force, conp_dataset_dir_path = parse_args()
+
+    # import the crawler packages
+    sys.path.append(conp_dataset_dir_path)
+    from scripts.Crawlers.ZenodoCrawler import ZenodoCrawler
+    from scripts.Crawlers.OSFCrawler import OSFCrawler
+
     try:
         if verbose:
             print("==================== Zenodo Crawler Running ====================" + os.linesep)
-        ZenodoCrawler = ZenodoCrawler(github_token, config_path, verbose, force)
-        ZenodoCrawler.run()
+        ZenodoCrawlerObj = ZenodoCrawler(github_token, config_path, verbose, force)
+        ZenodoCrawlerObj.run()
 
         if verbose:
             print(os.linesep + "==================== OSF Crawler Running ====================" + os.linesep)
-        OSFCrawler = OSFCrawler(github_token, config_path, verbose, force)
-        OSFCrawler.run()
+        OSFCrawlerObj = OSFCrawler(github_token, config_path, verbose, force)
+        OSFCrawlerObj.run()
 
         # INSTANTIATE NEW CRAWLERS AND RUN HERE
 


### PR DESCRIPTION
## Description

This modifies the code of the crawler so that the conp-dataset path can be configured and not hardcoded.

In `.conp_crawler_config.json`, the following needs to be added to the config file:
```
  "conp-dataset_path": "PATH TO THE conp-dataset DIRECTORY",
```

Then the scripts will load the ZenodoCrawler and OSFCrawler libraries based on that path.

NOTE: this config has already been added to the `.conp_crawler_config.json` file of `conp-bot@zenodo-crawl.acelab.ca`

