### PR TITLE
Recreate README.md if it does not exist

### DIFF
--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -274,6 +274,10 @@ class BaseCrawler:
                     # Create DATS.json if it doesn't exist
                     if not os.path.isfile(os.path.join(dataset_dir, "DATS.json")):
                         self._create_new_dats(dataset_dir, os.path.join(dataset_dir, "DATS.json"), dataset_description)
+                    # Create README.md if it doesn't exist
+                    if not os.path.isfile(os.path.join(dataset_dir, "README.md")):
+                        readme = self.get_readme_content(dataset_description)
+                        self._create_readme(readme, os.path.join(dataset_dir, "README.md"))
                     d.save()
                     d.publish(to="origin")
                 commit_msg = "Updated " + dataset_description["title"]


### PR DESCRIPTION
## Description

In the case the dataset is updated, the README.md file is not recreated. I missed that part yesterday when I refactored the crawler so that it could use the DATS.json and README.md uploaded by users through Zenodo or OSF.

This fixes it and add the creation of README.md file if a dataset is updated (note: this is done by default for new datasets).

## Related issues (optional)

This should fix the current issue with PR #448 