### PR TITLE
Download OSF files from all storage type instead of just osfstorage

### DIFF
--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -139,12 +139,8 @@ class OSFCrawler(BaseCrawler):
                                     dataset["relationships"]
                                     ["license"]["links"]["related"]["href"])
 
-            # Get dataset root folder files link
-            root_folder_link = self._get_request_with_bearer_token(
-                dataset["relationships"]["files"]["links"]["related"]["href"])\
-                .json()["data"][0]["relationships"]["root_folder"]["links"]["related"]["href"]
-            files_link = self._get_request_with_bearer_token(root_folder_link)\
-                .json()["data"]["relationships"]["files"]["links"]["related"]["href"]
+            # Get link for the dataset files
+            files_link = dataset['relationships']['files']['links']['related']['href']
 
             osf_dois.append(
                 {


### PR DESCRIPTION
## Description

Currently, the OSF crawler only supports crawling files that are stored in `osfstorage` data provider. However some datasets might have files in other types of data provider (for example `github`). 

The changes allow the support of crawling files from multiple data providers and therefore modify the way the OSF datasets will be organized in `conp-dataset`:
```
__ conp-dataset-Multimodal-data-with-wide-field-GCaMP-imaging
    |__ .datalad/
    |__ Part_1/
    |__ Part_2/
    |__ .conp-osf-crawler.json
    |__ .gitattributes
    |__ DATS.json
    |__ README.md
```
to 
```
__ conp-dataset-Multimodal-data-with-wide-field-GCaMP-imaging
    |__ .datalad/
    |__ osfstorage/
         |__ Part_1/
         |__ Part_2/
    |__ .conp-osf-crawler.json
    |__ .gitattributes
    |__ DATS.json
    |__ README.md
```

## Related issues

Should resolve: https://github.com/CONP-PCNO/conp-dataset/issues/430