### PR TITLE
[OSF crawler] Get the size of annexed files from git-annex info if it is not present in the OSF API response

### DIFF
--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -108,7 +108,10 @@ class OSFCrawler(BaseCrawler):
                 # append the size of the downloaded file to the sizes array
                 file_size = file['attributes']['size']
                 if not file_size:
-                    file_size = annex('info', '--bytes', os.path.join(inner_path, file["attributes"]["name"]))
+                    # if the file size cannot be found in the OSF API response, then get it from git annex info
+                    inner_file_path = os.path.join(inner_path, file["attributes"]["name"])
+                    annex_info_dict = json.loads(annex('info', '--bytes', '--json', inner_file_path))
+                    file_size       = int(annex_info_dict['size'])
                 sizes.append(file_size)
 
     def _get_contributors(self, link):

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -87,7 +87,6 @@ class OSFCrawler(BaseCrawler):
                     correct_download_link = self._get_request_with_bearer_token(
                         file["links"]["download"], redirect=False).headers['location']
                     if 'https://accounts.osf.io/login' not in correct_download_link:
-                        sizes.append(file["attributes"]["size"])
                         zip_file = True if file["attributes"]["name"].split(".")[-1] == "zip" else False
                         d.download_url(correct_download_link, path=os.path.join(inner_path, ""), archive=zip_file)
                     else:  # Token did not work for downloading file, return
@@ -96,7 +95,6 @@ class OSFCrawler(BaseCrawler):
 
                 # Public file
                 else:
-                    sizes.append(file["attributes"]["size"])
                     # Handle zip files
                     if file["attributes"]["name"].split(".")[-1] == "zip":
                         d.download_url(file["links"]["download"], path=os.path.join(inner_path, ""), archive=True)
@@ -106,6 +104,12 @@ class OSFCrawler(BaseCrawler):
                         annex("addurl", file["links"]["download"], "--fast", "--file",
                               os.path.join(inner_path, file["attributes"]["name"]))
                         d.save()
+
+                # append the file size
+                file_size = file['attributes']['size']
+                if not file_size:
+                    file_size = annex('info', '--bytes', os.path.join(inner_path, file["attributes"]["name"]))
+                sizes.append(file_size)
 
     def _get_contributors(self, link):
         r = self._get_request_with_bearer_token(link)

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -105,7 +105,7 @@ class OSFCrawler(BaseCrawler):
                               os.path.join(inner_path, file["attributes"]["name"]))
                         d.save()
 
-                # append the file size
+                # append the size of the downloaded file to the sizes array
                 file_size = file['attributes']['size']
                 if not file_size:
                     file_size = annex('info', '--bytes', os.path.join(inner_path, file["attributes"]["name"]))


### PR DESCRIPTION
## Description

OSF supports multiple data providers. In the case of Github data provider (and probably all non-OSF Storage data provider), the file size information is not available in the API response. This causes the crawler to crash with the following error:

```
Traceback (most recent call last):
  File "./scripts/crawl.py", line 84, in <module>
    OSFCrawlerObj.run()
  File "/data/crawler/conp-dataset/scripts/Crawlers/BaseCrawler.py", line 254, in run
    self.add_new_dataset(dataset_description, dataset_dir)
  File "/data/crawler/conp-dataset/scripts/Crawlers/OSFCrawler.py", line 207, in add_new_dataset
    dataset_size, dataset_unit = humanize.naturalsize(sum(dataset_size)).split(" ")
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

The proposed fix will compute the file_size using the `git annex info --bytes <file>` command and will append it to the `dataset_size` array.

## Related issue

This is currently blocking the addition of the CFMM-7T: MP2RAGE T1 mapping dataset.