### PR TITLE
[Crawler] Resolves the deprecation notice regarding Github token in URL

### DIFF
--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -341,8 +341,7 @@ class BaseCrawler:
         # Create PR
         print("Creating PR for " + title)
         r = requests.post(
-            "https://api.github.com/repos/CONP-PCNO/conp-dataset/pulls?access_token="
-            + self.github_token,
+            "https://api.github.com/repos/CONP-PCNO/conp-dataset/pulls",
             json={
                 "title": "Crawler result ({})".format(title),
                 "body": """## Description
@@ -368,6 +367,7 @@ Functional checks:
                 "head": self.username + ":conp-bot/" + clean_title,
                 "base": "master",
             },
+            headers={"Authorization": "token {}".format(self.github_token)}
         )
         if r.status_code != 201:
             raise Exception("Error while creating pull request: " + r.text)


### PR DESCRIPTION
## Description

Github is deprecating the API authentication through query parameters. Instead, they recommend users move the authentication in the header of the request.

This PR modifies our crawler to use authentication in the header of the request.

## Related issues (optional)

See Github documentation: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
