### PR TITLE
Add URI format validation

### DIFF
--- a/scripts/dats_validator/requirements.txt
+++ b/scripts/dats_validator/requirements.txt
@@ -4,6 +4,7 @@ importlib-metadata==1.3.0
 jsonschema==3.2.0
 more-itertools==8.0.2
 pyrsistent==0.15.7
+rfc3987==1.3.8
 six==1.13.0
 wincertstore==0.2
 zipp==0.6.0

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -44,7 +44,7 @@ def validate_json(json_obj):
     with open(SCHEMA_PATH) as s:
         json_schema = json.load(s)
     # first validate schema file
-    v = jsonschema.Draft4Validator(json_schema)
+    v = jsonschema.Draft4Validator(json_schema, format_checker=jsonschema.FormatChecker())
     # now validate json file
     try:
         jsonschema.validate(json_obj, json_schema, format_checker=jsonschema.FormatChecker())


### PR DESCRIPTION
## Description
The PR adds URI format validation to dats validator script.

**Example:** distribution->access->landingPage has a type `string` and format set to `uri`.
If the provided URI  is not of a valid format it will throw an error.

**Important:** e.g. `www.internationalgenome.org` is not a valid URI.
URI must start with a naming schema (e.g.: `http:`, `urn:`, `mailto:` etc.).
