### PR TITLE
Add derivedFrom validation

### DIFF
--- a/scripts/dats_validator/examples/invalid_dats.json
+++ b/scripts/dats_validator/examples/invalid_dats.json
@@ -2874,6 +2874,14 @@
           "value": "logo.png"
         }
       ]
+    },
+    {
+      "category": "derivedFrom",
+      "values": [
+        {
+          "value": "https://github.com/sdajdhajhdahdj"
+        }
+      ]
     }
   ]
 }

--- a/scripts/dats_validator/requirements.txt
+++ b/scripts/dats_validator/requirements.txt
@@ -1,9 +1,13 @@
 attrs==19.3.0
 certifi==2019.11.28
+chardet==3.0.4
+idna==2.10
 importlib-metadata==1.3.0
 jsonschema==3.2.0
 more-itertools==8.0.2
 pyrsistent==0.15.7
+requests==2.25.0
 six==1.13.0
+urllib3==1.26.2
 wincertstore==0.2
 zipp==0.6.0

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -1,4 +1,6 @@
 import jsonschema
+import requests
+
 import os
 import json
 import logging
@@ -51,7 +53,7 @@ def validate_json(json_obj):
         logger.info("JSON schema validation passed.")
         return True
     except jsonschema.exceptions.ValidationError:
-        errors = [e for e in v.iter_errors((json_obj))]
+        errors = [e for e in v.iter_errors(json_obj)]
         logger.info(f"The file is not valid. Total json schema errors: {len(errors)}")
         for i, error in enumerate(errors, 1):
             logger.error(f"{i} Validation error in {'.'.join(str(v) for v in error.path)}: {error.message}")
@@ -80,6 +82,14 @@ def validate_extra_properties(dataset):
                     error_message = f"Validation error in {dataset['title']}: extraProperties.category." \
                                     f"CONP_status - {each_value} is not allowed value for CONP_status. " \
                                     f"Allowed values are {REQUIRED_EXTRA_PROPERTIES['CONP_status']}."
+                    errors.append(error_message)
+
+        # checks if 'derivedFrom' values refer to existing datasets accessible online
+        if "derivedFrom" in extra_prop_categories:
+            for value in extra_prop_categories["derivedFrom"]:
+                if not dataset_exists(value):
+                    error_message = f"Validation error in {dataset['title']}: extraProperties.category." \
+                                    f"derivedFrom - {value} is not found. "
                     errors.append(error_message)
 
         if errors:
@@ -118,6 +128,31 @@ def validate_non_schema_required(json_obj):
     else:
         logger.info(f"Required extra properties validation passed.")
         return True
+
+
+# cache responses to avoid redundant calls
+cache = dict()
+
+
+def dataset_exists(derived_from_url):
+    """ Caches response values in cache dict. """
+
+    if derived_from_url not in cache:
+        cache[derived_from_url] = get_response_status(derived_from_url)
+    return cache[derived_from_url]
+
+
+def get_response_status(derived_from_url):
+    """ Get a response status code for derivedFrom value. Returns True if status code is 200."""
+
+    try:
+        r = requests.get(derived_from_url)
+        r.raise_for_status()
+        if r.status_code == 200:
+            return True
+
+    except requests.exceptions.HTTPError:
+        return False
 
 
 def help():


### PR DESCRIPTION
## Description
The PR addresses the extraProperties category `derivedFrom` validation.

- The code validates `derivedFrom`  value which is expected to be a valid url: sends request and checks if the response status code is 200.

- The code is not bounded to the GitHub API because I assume we might have cases when the `derivedFrom` points to the dataset persistent identifiers on other data portals or doi.org.

- To avoid redundant calls response statuses are stored in in-memory cache dict.

## Related issues (optional)
#436 
