### PR TITLE
Adding preventad-registered to the conp-dataset super dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -149,3 +149,6 @@
 [submodule "projects/CFMM_7T__MP2RAGE_T1_mapping"]
 	path = projects/CFMM_7T__MP2RAGE_T1_mapping
 	url = https://github.com/conp-bot/conp-dataset-CFMM-7T-MP2RAGE-T1-mapping.git
+[submodule "projects/preventad-registered"]
+    path = projects/preventad-registered
+    url = https://github.com/conpdatasets/preventad-registered.git


### PR DESCRIPTION
## Description

This will add the preventad-registered dataset to the conp-dataset. 

NOTE: a DOI will be created on Monday upon the official release of PREVENT-AD registered and this PR will be updated with the correct DOI once we have it.


## Checklist
<!--- Task to do for an approval of the pull request -->

Mandatory files and elements:
- [x] A `README.md` file, at the root of the dataset
- [x] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [x] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [x] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [x] Every data file has a URL
- [x] Every data file can be retrieved or requires authentication
- [x] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
