### PR TITLE
[OSF crawler] Add more OSF metadata to DATS.json and README for the OSF crawler

### DIFF
--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -232,7 +232,7 @@ class OSFCrawler(BaseCrawler):
                             "landingPage"   : dataset["links"]["html"],
                             "authorizations": [
                                 {
-                                    "value": "public"
+                                    "value": "public" if attributes['public'] else "private"
                                 }
                             ],
                         },

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -318,10 +318,17 @@ class OSFCrawler(BaseCrawler):
             return True
 
     def get_readme_content(self, dataset):
-        return """# {}
+        readme_content = """# {}
 
 Crawled from [OSF]({})
 
 ## Description
 
 {}""".format(dataset["title"], dataset["homepage"], dataset["description"])
+
+        if 'identifier' in dataset:
+            readme_content += """
+
+DOI: {}""".format(dataset['identifier']['identifier'])
+
+        return readme_content

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -162,6 +162,27 @@ class OSFCrawler(BaseCrawler):
             # Get link for the dataset files
             files_link = dataset['relationships']['files']['links']['related']['href']
 
+            # Gather extra properties
+            extra_properties = [
+                {
+                    "category": "logo",
+                    "values"  : [
+                        {
+                            "value": "https://osf.io/static/img/institutions/shields/cos-shield.png"
+                        }
+                    ],
+                }
+            ]
+            if institutions:
+                extra_properties.append(
+                    {
+                        "category": "origin_institution",
+                        "values"  : list(
+                            map(lambda x: {'value': x}, institutions)
+                        )
+                    }
+                )
+
             osf_dois.append(
                 {
                     "title": attributes["title"],
@@ -192,22 +213,7 @@ class OSFCrawler(BaseCrawler):
                             },
                         }
                     ],
-                    "extraProperties": [
-                        {
-                            "category": "origin_institution",
-                            "values": list(
-                                map(lambda x: {'value': x}, institutions)
-                            )
-                        },
-                        {
-                            "category": "logo",
-                            "values": [
-                                {
-                                    "value": "https://osf.io/static/img/institutions/shields/cos-shield.png"
-                                }
-                            ],
-                        }
-                    ],
+                    "extraProperties": extra_properties,
                 }
             )
 

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -4,6 +4,7 @@ import os
 import json
 import requests
 import humanize
+import datetime
 
 
 def _create_osf_tracker(path, dataset):
@@ -190,6 +191,10 @@ class OSFCrawler(BaseCrawler):
                     }
                 )
 
+            # Retrieve dates
+            date_created  = datetime.datetime.strptime(attributes['date_created'], '%Y-%m-%dT%H:%M:%S.%f')
+            date_modified = datetime.datetime.strptime(attributes['date_modified'], '%Y-%m-%dT%H:%M:%S.%f')
+
             dataset_dats_content = {
                 "title"          : attributes["title"],
                 "files"          : files_link,
@@ -202,6 +207,20 @@ class OSFCrawler(BaseCrawler):
                 "licenses"       : [
                     {
                         "name": license_
+                    }
+                ],
+                "dates": [
+                    {
+                        "date": date_created.strftime('%Y-%m-%d %H:%M:%S'),
+                        "type": {
+                            "value": "Date Created"
+                        }
+                    },
+                    {
+                        "date": date_modified.strftime('%Y-%m-%d %H:%M:%S'),
+                        "type": {
+                            "value": "Date Modified"
+                        }
                     }
                 ],
                 "keywords"       : keywords,

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -134,8 +134,6 @@ class OSFCrawler(BaseCrawler):
                 institution['attributes']['name'] for institution in r.json()['data']
             ]
             return institutions
-        else:
-            return False
 
     def _get_identifier(self, link):
         r = self._get_request_with_bearer_token(link)

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -164,7 +164,6 @@ class OSFCrawler(BaseCrawler):
             institutions = self._get_institutions(dataset['relationships']['affiliated_institutions']['links']['related']['href'])
 
             # Retrieve identifier information
-            dats_identifier_section = ''
             identifier = self._get_identifier(dataset['relationships']['identifiers']['links']['related']['href'])
 
             # Get link for the dataset files

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -126,6 +126,16 @@ class OSFCrawler(BaseCrawler):
         r = self._get_request_with_bearer_token(link)
         return r.json()["data"]["attributes"]["name"]
 
+    def _get_institutions(self, link):
+        r = self._get_request_with_bearer_token(link)
+        if r.json()['data']:
+            institutions = [
+                institution['attributes']['name'] for institution in r.json()['data']
+            ]
+            return institutions
+        else:
+            return False
+
     def get_all_dataset_description(self):
         osf_dois = []
         datasets = self._query_osf()
@@ -145,6 +155,9 @@ class OSFCrawler(BaseCrawler):
                 license_ = self._get_license(
                                     dataset["relationships"]
                                     ["license"]["links"]["related"]["href"])
+
+            # Retrieve institution information
+            institutions = self._get_institutions(dataset['relationships']['affiliated_institutions']['links']['related']['href'])
 
             # Get link for the dataset files
             files_link = dataset['relationships']['files']['links']['related']['href']
@@ -180,6 +193,12 @@ class OSFCrawler(BaseCrawler):
                         }
                     ],
                     "extraProperties": [
+                        {
+                            "category": "origin_institution",
+                            "values": list(
+                                map(lambda x: {'value': x}, institutions)
+                            )
+                        },
                         {
                             "category": "logo",
                             "values": [


### PR DESCRIPTION
## Description

This adds the following metadata to the automatically generated DATS.json from the OSF crawler:
- origin_institution (when there are institutions associated to the dataset in the OSF API response)
- identifier and identifier source (when there is a DOI associated to the dataset in the OSF API response
- date created
- date modified

When an identifier is present, it is also added to the end of the README file.

Documentation of the API endpoints can be found here: https://github.com/CONP-PCNO/conp-documentation/pull/49

Related issue: #375
