### PR TITLE
Handling OSF components

### DIFF
--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -129,8 +129,8 @@ class OSFCrawler(BaseCrawler):
                 annex,
                 dataset_size
             )
-            
-            # check if the component contain (sub)components, in which case, download the (sub)components data
+
+            # check if the component contains (sub)components, in which case, download the (sub)components data
             subcomponents_list = self._get_components(component['relationships']['children']['links']['related']['href'])
             if subcomponents_list:
                 self._download_components(

--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -201,19 +201,6 @@ class OSFCrawler(BaseCrawler):
             # Get components list
             components_list = self._get_components(dataset['relationships']['children']['links']['related']['href'])
 
-            osf_dois.append(
-                {
-                    "title": attributes["title"],
-                    "files": files_link,
-                    "components_list": components_list,
-                    "homepage": dataset["links"]["html"],
-                    "creators": list(
-                        map(lambda x: {"name": x}, contributors)
-                    ),
-                    "description": attributes["description"],
-                    "version": attributes["date_modified"],
-                    "licenses": [
-
             # Gather extra properties
             extra_properties = [
                 {
@@ -242,6 +229,7 @@ class OSFCrawler(BaseCrawler):
             dataset_dats_content = {
                 "title"          : attributes["title"],
                 "files"          : files_link,
+                "components_list": components_list,
                 "homepage"       : dataset["links"]["html"],
                 "creators"       : list(
                     map(lambda x: {"name": x}, contributors)


### PR DESCRIPTION
## Description

This modifies the OSF crawler to support components. 

- When a dataset contains OSF components (example: https://osf.io/xhvsk/), then the content of the components will be crawled along with the other files from the dataset.

- For datasets that have a parent key in the API response (a.k.a. the dataset is a component of another OSF dataset), the crawler will skip that dataset since its content is going to be part of the parent dataset linked.

Notes:
- #477 conp-bot PR is the result of the crawler modifications present in the PR
- #405 and #406 were two earlier PRs for components dataset. Since the files are now in #477, those two PRs have been closed.

## Related issues 

https://github.com/CONP-PCNO/conp-dataset/issues/419