### PR TITLE
removing expression-based polygenic risk score dataset from CONP data interface.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -131,9 +131,6 @@
 [submodule "projects/Numerically_Perturbed_Structural_Connectomes_from_100_individuals_in_the_NKI_Rockland_Dataset"]
 	path = projects/Numerically_Perturbed_Structural_Connectomes_from_100_individuals_in_the_NKI_Rockland_Dataset
 	url = https://github.com/conp-bot/conp-dataset-Numerically-Perturbed-Structural-Connectomes-from-100-individuals-in-the-NKI-Rockland-D.git
-[submodule "projects/Expression_based_polygenic_score_from_the_amygdala_5HTT_gene_network"]
-	path = projects/Expression_based_polygenic_score_from_the_amygdala_5HTT_gene_network
-	url = https://github.com/conp-bot/conp-dataset-Expression-based-polygenic-score-from-the-amygdala-5HTT-gene-network.git
 [submodule "projects/mousebytesdataset"]
 	path = projects/mousebytesdataset
 	url = https://github.com/conpdatasets/mousebytesdataset.git


### PR DESCRIPTION
At a meeting the morning December 18 2020, it was decided that the example data stored in https://github.com/conp-bot/conp-dataset-Expression-based-polygenic-score-from-the-amygdala-5HTT-gene-network/ was more appropriately added as an auxiliary to https://github.com/SilveiraLab/ePRS and made available along with pipelines, so this PR removes that dataset from https://github.com/CONP-PCNO/conp-dataset. 
