### PR TITLE
updating calgary-campinas submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,9 +143,6 @@
 [submodule "projects/preventad-registered"]
     path = projects/preventad-registered
     url = https://github.com/conpdatasets/preventad-registered.git
-[submodule "projects/calgary-campinas"]
-	path = projects/calgary-campinas
-	url = https://github.com/conpdatasets/calgary-campinas.git
 [submodule "projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations"]
 	path = projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations
 	url = https://github.com/conpdatasets/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations

--- a/.gitmodules
+++ b/.gitmodules
@@ -149,5 +149,5 @@
 [submodule "projects/calgary-campinas"]
 	path = projects/calgary-campinas
 	url = https://github.com/conpdatasets/calgary-campinas.git
-	branch = master
+	branch = main
 	datalad-id = 95f9d92a-3414-11eb-8a50-525400da244d

--- a/.gitmodules
+++ b/.gitmodules
@@ -146,3 +146,8 @@
 [submodule "projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations"]
 	path = projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations
 	url = https://github.com/conpdatasets/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations
+[submodule "calgary-campinas"]
+	path = calgary-campinas
+	url = https://github.com/conpdatasets/calgary-campinas.git
+	branch = master
+	datalad-id = 95f9d92a-3414-11eb-8a50-525400da244d

--- a/.gitmodules
+++ b/.gitmodules
@@ -146,8 +146,8 @@
 [submodule "projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations"]
 	path = projects/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations
 	url = https://github.com/conpdatasets/Multi-model_functionalization_of_disease-associated_PTEN_missense_mutations
-[submodule "calgary-campinas"]
-	path = calgary-campinas
+[submodule "projects/calgary-campinas"]
+	path = projects/calgary-campinas
 	url = https://github.com/conpdatasets/calgary-campinas.git
 	branch = master
 	datalad-id = 95f9d92a-3414-11eb-8a50-525400da244d


### PR DESCRIPTION
This PR updates `conp-dataset/projects` to remove and reinstall the `calgary-campinas` submodule in the hope of fixing odd behaviour with `.git` folders that was preventing it from showing in the CONP portal interface.