### PR TITLE
Modifies validator to flag unusual values for the DATS 'formats' field

### DIFF
--- a/scripts/dats_validator/examples/invalid_dats.json
+++ b/scripts/dats_validator/examples/invalid_dats.json
@@ -22,7 +22,7 @@
       }
     }
   ],
-  "title": "1000 Genomes Project",
+  "title": "1000 Genomes Project - Invalid Example For Test Validator",
   "description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
   "storedIn": {
     "name": "European Bioinformatics Institute"
@@ -69,7 +69,7 @@
     {
       "formats": [
         ".VCF",
-        "FASTA"
+        "fasta"
       ],
       "size": 16.2,
       "unit": {

--- a/scripts/dats_validator/examples/valid_dats.json
+++ b/scripts/dats_validator/examples/valid_dats.json
@@ -22,7 +22,7 @@
       }
     }
   ],
-  "title": "1000 Genomes Project",
+  "title": "1000 Genomes Project - Valid Test Example For Validator",
   "description": "The 1000 Genomes Project provides a comprehensive description of common human variation by applying a combination of whole-genome sequencing, deep exome sequencing and dense microarray genotyping to a diverse set of 2504 individuals from 26 populations.  Over 88 million variants are characterised, including >99% of SNP variants with a frequency of >1% for a variety of ancestries.",
   "storedIn": {
     "name": "European Bioinformatics Institute"
@@ -68,7 +68,7 @@
   "distributions": [
     {
       "formats": [
-        ".VCF",
+        "VCF",
         "FASTA"
       ],
       "size": 16.2,
@@ -121,7 +121,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 1.19,
           "unit": {
@@ -231,7 +231,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 755,
           "unit": {
@@ -341,7 +341,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 749,
           "unit": {
@@ -451,7 +451,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 723,
           "unit": {
@@ -561,7 +561,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 543,
           "unit": {
@@ -671,7 +671,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 494,
           "unit": {
@@ -781,7 +781,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 447,
           "unit": {
@@ -891,7 +891,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 483,
           "unit": {
@@ -1001,7 +1001,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 424,
           "unit": {
@@ -1111,7 +1111,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 426,
           "unit": {
@@ -1221,7 +1221,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 351,
           "unit": {
@@ -1331,7 +1331,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 1.28,
           "unit": {
@@ -1441,7 +1441,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 334,
           "unit": {
@@ -1551,7 +1551,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 213,
           "unit": {
@@ -1661,7 +1661,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 209,
           "unit": {
@@ -1771,7 +1771,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 1.08,
           "unit": {
@@ -1881,7 +1881,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 1.09,
           "unit": {
@@ -1991,7 +1991,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 966,
           "unit": {
@@ -2101,7 +2101,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 976,
           "unit": {
@@ -2211,7 +2211,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 886,
           "unit": {
@@ -2321,7 +2321,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 841,
           "unit": {
@@ -2431,7 +2431,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 657,
           "unit": {
@@ -2541,7 +2541,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 202,
           "unit": {
@@ -2651,7 +2651,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 1.87,
           "unit": {
@@ -2761,7 +2761,7 @@
       "distributions": [
         {
           "formats": [
-            ".VCF"
+            "VCF"
           ],
           "size": 5.73,
           "unit": {

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -110,7 +110,7 @@ def validate_formats(dataset):
     """ Checks if the values in the formats field of the JSON object follows the upper case convention without dots. """
 
     errors_list = []
-    format_exceptions = ['bigWig', 'NIfTI', 'RNA-Seq']
+    format_exceptions = ['bigWig', 'NIfTI', 'GIfTI', 'RNA-Seq']
 
     # check that distributions have a formats property as this is required in the schema
     for distribution_dict in dataset['distributions']:

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -6,7 +6,6 @@ import json
 import logging
 import getopt
 from sys import argv
-from functools import reduce
 
 
 logger = logging.getLogger(__name__)

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -6,6 +6,7 @@ import json
 import logging
 import getopt
 from sys import argv
+from functools import reduce
 
 
 logger = logging.getLogger(__name__)
@@ -105,10 +106,45 @@ def validate_extra_properties(dataset):
                         f"{[k for k in REQUIRED_EXTRA_PROPERTIES.keys()]}")
 
 
+def validate_formats(dataset):
+    """ Checks if the values in the formats field of the JSON object follows the upper case convention without dots. """
+
+    errors_list = []
+    format_exceptions = ['bigWig', 'NIfTI', 'RNA-Seq']
+
+    # check that distributions have a formats property as this is required in the schema
+    for distribution_dict in dataset['distributions']:
+        if 'formats' not in distribution_dict.keys():
+            error_message = f"Validation error in {dataset['title']}: distributions." \
+                            f"formats - 'formats' property is missing under distributions. " \
+                            f"Please add the 'formats' property to 'distributions'."
+            errors_list.append(error_message)
+        else:
+            for file_format in distribution_dict['formats']:
+                if file_format != file_format.upper() and file_format not in format_exceptions:
+                    error_message = f"Validation error in {dataset['title']}: distributions." \
+                                    f"formats - {file_format} is not allowed. " \
+                                    f"Allowed value should either be capitalized or one of {format_exceptions}. " \
+                                    f"Consider changing the value to {file_format.strip('.').upper()}. "
+                    errors_list.append(error_message)
+                elif file_format.startswith('.'):
+                    error_message = f"Validation error in {dataset['title']}: distributions." \
+                                    f"formats - {file_format} is not allowed. " \
+                                    f"Format values should not start with a dot."
+                    errors_list.append(error_message)
+
+    if errors_list:
+        return False, errors_list
+    else:
+        return True, errors_list
+
+
 def validate_recursively(obj, errors):
     """ Checks all datasets recursively for required extraProperties. """
 
     val, errors_list = validate_extra_properties(obj)
+    errors.extend(errors_list)
+    val, errors_list = validate_formats(obj)
     errors.extend(errors_list)
     if "hasPart" in obj:
         for each in obj["hasPart"]:
@@ -124,10 +160,10 @@ def validate_non_schema_required(json_obj):
         logger.info(f"Total required extra properties errors: {len(errors)}")
         for i, er in enumerate(errors, 1):
             logger.error(f"{i} {er}")
-        return False
+        return False, errors
     else:
         logger.info(f"Required extra properties validation passed.")
-        return True
+        return True, None
 
 
 # cache responses to avoid redundant calls

--- a/tests/template.py
+++ b/tests/template.py
@@ -68,19 +68,18 @@ class Template(object):
             # For datasets crawled with Zenodo: check the formats extra property only
             # For datasets crawled with OSF: skip validation of extra properties
             is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler.json'))
-            if is_osf_dataset:
-                return
             is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler.json'))
             is_valid, errors = validate_formats(json_obj) if is_zenodo_dataset else validate_non_schema_required(json_obj)
             if not is_valid:
-                summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
-                                        f"in required extra properties or formats. List of errors:\n"
-                for i, error_message in enumerate(errors, 1):
-                    summary_error_message += f"- {i}. {error_message}\n"
-                pytest.fail(
-                    summary_error_message,
-                    pytrace=False,
-                )
+                if not is_osf_dataset:
+                    summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
+                                            f"in required extra properties or formats. List of errors:\n"
+                    for i, error_message in enumerate(errors, 1):
+                        summary_error_message += f"- {i}. {error_message}\n"
+                    pytest.fail(
+                        summary_error_message,
+                        pytrace=False,
+                    )
 
     def test_download(self, dataset):
         eval_config(dataset)

--- a/tests/template.py
+++ b/tests/template.py
@@ -67,8 +67,8 @@ class Template(object):
             # automatically populate some of the fields
             # For datasets crawled with Zenodo: check the formats extra property only
             # For datasets crawled with OSF: skip validation of extra properties
-            is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler'))
-            is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler'))
+            is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler.json'))
+            is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler.json'))
             is_valid, errors = validate_formats(json_obj) if is_zenodo_dataset else validate_non_schema_required(json_obj)
             if not is_valid and not is_osf_dataset:
                 summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \

--- a/tests/template.py
+++ b/tests/template.py
@@ -70,8 +70,7 @@ class Template(object):
             is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler.json'))
             is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler.json'))
             is_valid, errors = validate_formats(json_obj) if is_zenodo_dataset else validate_non_schema_required(json_obj)
-            if not is_valid:
-                if not is_osf_dataset:
+            if not is_valid and not is_osf_dataset:
                     summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
                                             f"in required extra properties or formats. List of errors:\n"
                     for i, error_message in enumerate(errors, 1):

--- a/tests/template.py
+++ b/tests/template.py
@@ -9,7 +9,11 @@ from datalad import api
 import git
 import pytest
 
-from scripts.dats_validator.validator import validate_json
+from scripts.dats_validator.validator import (
+    validate_json,
+    validate_non_schema_required,
+    validate_formats
+)
 from tests.functions import (
     authenticate,
     download_files,
@@ -52,9 +56,27 @@ class Template(object):
             )
 
         with open(os.path.join(dataset, "DATS.json"), "rb") as f:
-            if not validate_json(json.load(f)):
+            json_obj = json.load(f)
+            if not validate_json(json_obj):
                 pytest.fail(
                     f"Dataset {dataset} doesn't contain a valid DATS.json.",
+                    pytrace=False,
+                )
+
+            # For crawled dataset, some tests should not be run as there is no way to
+            # automatically populate some of the fields
+            # For datasets crawled with Zenodo: check the formats extra property only
+            # For datasets crawled with OSF: skip validation of extra properties
+            is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler'))
+            is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler'))
+            is_valid, errors = validate_formats(json_obj) if is_zenodo_dataset else validate_non_schema_required(json_obj)
+            if not is_valid and not is_osf_dataset:
+                summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
+                                        f"in required extra properties or formats. List of errors:\n"
+                for i, error_message in enumerate(errors, 1):
+                    summary_error_message += f"- {i}. {error_message}\n"
+                pytest.fail(
+                    summary_error_message,
                     pytrace=False,
                 )
 

--- a/tests/template.py
+++ b/tests/template.py
@@ -68,9 +68,11 @@ class Template(object):
             # For datasets crawled with Zenodo: check the formats extra property only
             # For datasets crawled with OSF: skip validation of extra properties
             is_osf_dataset = os.path.exists(os.path.join(dataset, '.conp-osf-crawler.json'))
+            if is_osf_dataset:
+                return
             is_zenodo_dataset = os.path.exists(os.path.join(dataset, '.conp-zenodo-crawler.json'))
             is_valid, errors = validate_formats(json_obj) if is_zenodo_dataset else validate_non_schema_required(json_obj)
-            if not is_valid and not is_osf_dataset:
+            if not is_valid:
                 summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
                                         f"in required extra properties or formats. List of errors:\n"
                 for i, error_message in enumerate(errors, 1):

--- a/tests/test_dats_validator.py
+++ b/tests/test_dats_validator.py
@@ -34,8 +34,8 @@ class JsonschemaTest(unittest.TestCase):
 class ExtraPropertiesTest(unittest.TestCase):
 
     def test_non_schema_required(self):
-        valid_validation = validate_non_schema_required(valid_obj)
-        invalid_validation = validate_non_schema_required(invalid_obj)
+        valid_validation, errors = validate_non_schema_required(valid_obj)
+        invalid_validation, errors = validate_non_schema_required(invalid_obj)
         self.assertEqual(valid_validation, True)
         self.assertEqual(invalid_validation, False)
 


### PR DESCRIPTION
## Description

In order to harmonize DATS between datasets, a review of the available content for the distributions.formats field has been done and the following convention were determined:

file format should be capitalized without the dot preceding the format (exceptions being BigWig, NIfTI and RNA-Seq)
Examples of invalid format: tsv, .txt...
Examples of a valid format: TSV, TXT, MINC...

## Related issues

#491

Note: this is the same changes as in https://github.com/CONP-PCNO/conp-dataset/pull/498 but had to resubmit the PR as I pushed some dataset changes that should not have been in the PR modifying the validator and the tests...