### PR TITLE
Add validation of date type to the validator and the tests

### DIFF
--- a/scripts/dats_validator/examples/invalid_dats.json
+++ b/scripts/dats_validator/examples/invalid_dats.json
@@ -36,7 +36,7 @@
       "dates": [
         {
           "type": {
-            "value": "Primary reference publication date"
+            "value": "Primary Reference Publication Date"
           },
           "date": "2015-10-01 00:00:00"
         }
@@ -60,7 +60,7 @@
   "dates": [
     {
       "type": {
-        "value": "CONP DATS JSON fileset creation date"
+        "value": "CONP DATS JSON Fileset Creation Date"
       },
       "date": "2019-07-31 11:21:58"
     }
@@ -108,7 +108,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -210,7 +210,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -320,7 +320,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -430,7 +430,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -540,7 +540,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -650,7 +650,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -760,7 +760,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -870,7 +870,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -980,7 +980,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1090,7 +1090,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1200,7 +1200,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1310,7 +1310,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1420,7 +1420,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1530,7 +1530,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1640,7 +1640,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1750,7 +1750,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1860,7 +1860,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -1970,7 +1970,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2080,7 +2080,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2190,7 +2190,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2300,7 +2300,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2410,7 +2410,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2520,7 +2520,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-10-02 00:00:00"
         }
@@ -2630,7 +2630,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }
@@ -2740,7 +2740,7 @@
       "dates": [
         {
           "type": {
-            "value": "source .vcf file creation date"
+            "value": "Source .vcf File Creation Date"
           },
           "date": "2015-02-18 00:00:00"
         }

--- a/scripts/dats_validator/examples/valid_dats.json
+++ b/scripts/dats_validator/examples/valid_dats.json
@@ -60,7 +60,7 @@
   "dates": [
     {
       "type": {
-        "value": "CONP DATS fileset creation date"
+        "value": "CONP DATS JSON fileset creation date"
       },
       "date": "2019-07-31 11:21:58"
     }

--- a/scripts/dats_validator/examples/valid_dats.json
+++ b/scripts/dats_validator/examples/valid_dats.json
@@ -36,7 +36,7 @@
       "dates": [
         {
           "type": {
-            "value": "Primary reference publication date"
+            "value": "primary reference publication date"
           },
           "date": "2015-10-01 00:00:00"
         }
@@ -60,7 +60,7 @@
   "dates": [
     {
       "type": {
-        "value": "CONP DATS JSON fileset creation date"
+        "value": "CONP DATS fileset creation date"
       },
       "date": "2019-07-31 11:21:58"
     }

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -141,7 +141,7 @@ def validate_formats(dataset):
 def date_type_validation(dates_list, dataset_title):
 
     errors_list = []
-    date_type_exception = ['CONP DATS fileset creation date']
+    date_type_exception = ['CONP DATS JSON fileset creation date']
 
     for date_dict in dates_list:
         dtype = date_dict['type']['value']

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -138,12 +138,49 @@ def validate_formats(dataset):
         return True, errors_list
 
 
+def date_type_validation(dates_list, dataset_title):
+
+    errors_list = []
+    date_type_exception = ['CONP DATS fileset creation date']
+
+    for date_dict in dates_list:
+        dtype = date_dict['type']['value']
+        if dtype != dtype.lower() and dtype not in date_type_exception:
+            error_message = f"Validation error in {dataset_title}: dates.type - {dtype} is not allowed. " \
+                            f"Allowed value should either be all lower case or one of {date_type_exception}. " \
+                            f"Consider changing the value to {dtype.lower()}"
+            errors_list.append(error_message)
+
+    return errors_list
+
+def validate_date_types(dataset):
+    """ Checks if the values in the dates type field of the JSON object follows the lower case convention. """
+
+    errors_list = []
+
+    if 'dates' in dataset.keys():
+        dates_errors_list = date_type_validation(dataset['dates'], dataset['title'])
+        errors_list.extend(dates_errors_list)
+
+    if 'primaryPublications' in dataset.keys():
+        for publication in dataset['primaryPublications']:
+            if 'dates' in publication:
+                dates_errors_list = date_type_validation(publication['dates'], dataset['title'])
+                errors_list.extend(dates_errors_list)
+
+    if errors_list:
+        return False, errors_list
+    else:
+        return True, errors_list
+
 def validate_recursively(obj, errors):
     """ Checks all datasets recursively for required extraProperties. """
 
     val, errors_list = validate_extra_properties(obj)
     errors.extend(errors_list)
     val, errors_list = validate_formats(obj)
+    errors.extend(errors_list)
+    val, errors_list = validate_date_types(obj)
     errors.extend(errors_list)
     if "hasPart" in obj:
         for each in obj["hasPart"]:

--- a/tests/template.py
+++ b/tests/template.py
@@ -12,7 +12,8 @@ import pytest
 from scripts.dats_validator.validator import (
     validate_json,
     validate_non_schema_required,
-    validate_formats
+    validate_formats,
+    validate_date_types,
 )
 from tests.functions import (
     authenticate,
@@ -62,6 +63,18 @@ class Template(object):
                     f"Dataset {dataset} doesn't contain a valid DATS.json.",
                     pytrace=False,
                 )
+
+            # Validate the date type values
+            date_type_valid_bool, date_type_errors = validate_date_types(json_obj)
+            if not date_type_valid_bool:
+                summary_error_message = f"Dataset {dataset} contains DATS.json that has errors " \
+                                        f"in date's type encoding. List of errors:\n"
+                for i, error_message in enumerate(date_type_errors, 1):
+                    summary_error_message += f"- {i}. {error_message}\n"
+                    pytest.fail(
+                        summary_error_message,
+                        pytrace=False,
+                    )
 
             # For crawled dataset, some tests should not be run as there is no way to
             # automatically populate some of the fields


### PR DESCRIPTION
## Description

As an exercise towards DATS value harmonisation, the dates type have been harmonized to be all lower case with the exception of "CONP DATS fileset creation date".

This PR adds some functions to the validator and the automated tests to validate that the date type is indeed all lower case.

Note: since the DATS GUI is only suggesting to add dates to the dataset_schema.json and the primaryPublications section of the DATS file, the validation will only check those for now.

## Related issues 

#499