### PR TITLE
Fix encoding of date type to be all lower case for the DATS file

### DIFF
--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -252,13 +252,13 @@ class ZenodoCrawler(BaseCrawler):
                         {
                             "date": date_created.strftime('%Y-%m-%d %H:%M:%S'),
                             "type": {
-                                "value": "Date Created"
+                                "value": "date created"
                             }
                         },
                         {
                             "date": date_modified.strftime('%Y-%m-%d %H:%M:%S'),
                             "type": {
-                                "value": "Date Modified"
+                                "value": "date modified"
                             }
                         }
                     ],


### PR DESCRIPTION
## Description

The date type of the DATS file created by the Zenodo crawler are `Date Created` and `Date Modified`. This changes those strings to comply with lower case convention, ergo `date created` and `date modified` so that the crawler creates valid DATS files.

## Related issues 

#519, #499