### PR TITLE
[FIX] Docker workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Reference: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+`

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,3 +1,5 @@
+name: Docker build and push.
+
 on:
   push:
     paths:
@@ -9,16 +11,20 @@ on:
 jobs:
   build_push:
     runs-on: ubuntu-latest
-    name: Build a Docker image for conp-dataset and Push it to DockerHub.
+
     steps:
-      - name: Checkout repository
-        id: checkout
-        uses: actions/checkout@v2
-      - name: Docker build and push.
-        id: build_push
-        uses: docker/build-push-action@v1
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ secrets.DOCKERHUB_REPOSITORY }}
-          tags: latest
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
## Description
The current GitHub action for building and pushing the repo image to DockerHub is failing.
This is because the action uses a deprecated version of the `docker/build-push-action`.

This PR aims at updates the version for the docker action using the [current recommended approach](https://github.com/docker/build-push-action#git-context).

To be functional, this PR requires secrets for:

- [x] DOCKERHUB_USERNAME
- [x] DOCKERHUB_PASSWORD (should use a generated DockerHub Token)
- [x] DOCKERHUB_REPOSITORY