### PR TITLE
Handle crawler git pull errors

### DIFF
--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -93,9 +93,5 @@ if __name__ == "__main__":
         if repository.active_branch.name != "master":
             repository.git.checkout("master")
 
-        # Always clear .crawling touchfile
-        if ".crawling" in os.listdir("."):
-            os.remove(".crawling")
-
         if verbose:
             print(os.linesep + "==================== Done ====================")


### PR DESCRIPTION
## Error
Currently, in `crawl.sh`, if the command `git pull --no-edit main master` fails, the touchfile is never removed and the crawler will never execute since it will always see that the touchfile is present until someone manually removes it

`git pull` failling:
![image](https://user-images.githubusercontent.com/35869923/110898890-17da7a00-82ce-11eb-8dec-8e5eb755353c.png)


Crawler never starting again:
![image](https://user-images.githubusercontent.com/35869923/110898679-abf81180-82cd-11eb-89cd-a199a776384d.png)

## Fix
Only continue executing script if that command passes and handle creation and deletion of the touchfile in the shell script instead of letting the python script handle the deletion of the touchfile since the python script might not execute.

Also redirecting output of `git pull` to the logfile for easier debugging and allow for overriding the `BASEDIR` environment variable which is the path to the `conp-dataset` repo directory where the crawler does its job to allow other instances of the script to run in other locations