### PR TITLE
[ADD] Automatically label/close stale issues and pull requests.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
-          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days."
-          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
-          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
-          days-before-issue-stale: 30
+          stale-issue-message: "This issue is stale because it has been open 5 months with no activity. Remove stale label or comment or this will be closed in 3 months."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 20 days."
+          close-issue-message: "This issue was closed because it has been stalled for 3 months with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 20 days with no activity."
+          days-before-issue-stale: 150 # ~5 months
+          days-before-issue-close: 90 # ~3 months
           days-before-pr-stale: 45
-          days-before-issue-close: 5
-          days-before-pr-close: 10
+          days-before-pr-close: 20


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This PR aims to simplify the maintenance of issues and PRs.
The GitHub workflow proposed will automatically label issues and PRs as **stale** after a configured time. If no actions is taken after a set number of days, that issue/pr will be closed automatically.

### Proposed configuration:

- Issues:
  - label stale: 30 days
  - close after labeling: 5 days
- Pull requests:
  - label stale: 45 days
  - close after labeling: 10 days 