### PR TITLE
[MODIFY] Bump Python version to 3.9 in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &docker
-    - image: mathdugre/ci-conp-dataset:v1
+    - image: mathdugre/ci-conp-dataset:py39
 
   - &workdir ~/conp-dataset
 

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.6
+FROM circleci/python:3.9
 
 WORKDIR /home/circleci
 


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This PR aims at bumping the Python version to 3.9 in CircleCI.

It was discussed in #577 that the python typing module went through a lot of changes in the recent version.
Upgrading the Python version used for the development of the test suite would result in better readability and maintenance; see [PEP 585](https://www.python.org/dev/peps/pep-0585/).