### PR TITLE
Modify date type encoded by the OSF crawler to match DATS harmonization work

### DIFF
--- a/scripts/Crawlers/OSFCrawler.py
+++ b/scripts/Crawlers/OSFCrawler.py
@@ -261,13 +261,13 @@ class OSFCrawler(BaseCrawler):
                     {
                         "date": date_created.strftime('%Y-%m-%d %H:%M:%S'),
                         "type": {
-                            "value": "Date Created"
+                            "value": "date created"
                         }
                     },
                     {
                         "date": date_modified.strftime('%Y-%m-%d %H:%M:%S'),
                         "type": {
-                            "value": "Date Modified"
+                            "value": "date modified"
                         }
                     }
                 ],


### PR DESCRIPTION
## Description

This modifies how the date types are encoded to match with the DATS harmonization work that has been done. This was modified for the Zenodo crawler but not for the OSF crawler for some unclear reasons. Probably was just missed.

Related to #520 that corrected that for the Zenodo Crawler.