### PR TITLE
[FIX] Clear CircleCI cache by bumping the key version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ aliases:
     restore_cache:
       name: Restore Python Cache
       keys:
-        - python-deps-{{ checksum "requirements.txt" }}
-        - python-deps-
+        - py39-deps-{{ checksum "requirements.txt" }}
+        - py39-deps-
 
 jobs:
   build:
@@ -42,7 +42,7 @@ jobs:
           name: Save Python Cache
           paths:
             - ~/venv
-          key: python-deps-{{ checksum "requirements.txt" }}
+          key: py39-deps-{{ checksum "requirements.txt" }}
       - run:
           name: Install CONP-DATS Validator
           command: |


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
Bumping the Python version in #583 broke the CircleCI cache.

## Possible issues
Pip seems to find the package form the previous Python version thus skip the install and leaving the current Python version with no installed module.

## Proposed solution
Bump the cache key in the CircleCI configuration.

## Related issues
Origin of the issue: #583 
