### PR TITLE
Remove and Reorder pre-commit hooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,4 +142,3 @@
 [submodule "projects/openpain/subacute_longitudinal_study"]
 	path = projects/openpain/subacute_longitudinal_study
 	url = https://github.com/conpdatasets/openpain-subacute_longitudinal_study.git
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,16 +11,28 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: check-executables-have-shebangs
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
-    hooks:
-      - id: mypy
+  # Disable until a stable version of type annotation is out.
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.770
+  #   hooks:
+  #     - id: mypy
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.10.0
     hooks:
       - id: pyupgrade
         args: [--py3-plus]
+  # Docker Lint
+  - repo: https://github.com/pryorda/dockerfilelint-precommit-hooks
+    rev: v0.1.0
+    hooks:
+      - id: dockerfilelint
+        stages: [commit]
   # Style
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
@@ -28,12 +40,13 @@ repos:
       - id: check-docstring-first
       - id: pretty-format-json
         args: [--autofix]
+      - id: requirements-txt-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.4.0
     hooks:
-      - id: add-trailing-comma
-        args: [--py36-plus]
+      - id: reorder-python-imports
+        args: [--py3-plus]
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
@@ -43,23 +56,9 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==20.8b1]
-  - repo: https://github.com/pryorda/dockerfilelint-precommit-hooks
-    rev: v0.1.0
-    hooks:
-      - id: dockerfilelint
-        stages: [commit]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.1.1
-    hooks:
-      - id: pydocstyle
-        args: [--convention=numpy]
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.4.0
-    hooks:
-      - id: reorder-python-imports
-        args: [--py3-plus]
+  #  Disable until we are done documenting the code base.
+  # - repo: https://github.com/PyCQA/pydocstyle
+  #   rev: 5.1.1
+  #   hooks:
+  #     - id: pydocstyle
+  #       args: [--convention=numpy]

--- a/scripts/dats_validator/requirements.txt
+++ b/scripts/dats_validator/requirements.txt
@@ -6,8 +6,8 @@ importlib-metadata==1.3.0
 jsonschema==3.2.0
 more-itertools==8.0.2
 pyrsistent==0.15.7
-rfc3987==1.3.8
 requests==2.25.0
+rfc3987==1.3.8
 six==1.13.0
 urllib3==1.26.4
 wincertstore==0.2

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -122,7 +122,7 @@ def validate_extra_properties(dataset):
     # extraProperties is only required property which is not required on dataset_schema level,
     # if it's not present an Exception is raised
     except KeyError as e:
-        raise Exception(
+        raise KeyError(
             f"{e} is required."
             f"The following extra properties categories are required: "
             f"{[k for k in REQUIRED_EXTRA_PROPERTIES.keys()]}",

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-git-python==1.0.3
 datalad==0.13.3
+git-python==1.0.3
 html2markdown==0.1.7

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
 gitpython==3.1.7
+gitpython==3.1.7
 html2markdown==0.1.7
 humanfriendly==9.1
 humanize==2.5.0
+junitparser==1.4.1
 mock==4.0.2
 pytest==6.0.0
 pytest-xdist==1.34.0
-junitparser==1.4.1
-gitpython==3.1.7

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 gitpython==3.1.7
-gitpython==3.1.7
 html2markdown==0.1.7
 humanfriendly==9.1
 humanize==2.5.0

--- a/tests/test_dats_validator.py
+++ b/tests/test_dats_validator.py
@@ -40,7 +40,7 @@ class ExtraPropertiesTest(unittest.TestCase):
         # two possible key errors are extraProperties and title (the latter since it's used in error message)
         # introduce key error
         del modified_copy["extraProperties"]
-        with self.assertRaises(Exception):
+        with self.assertRaises(KeyError):
             validate_non_schema_required(modified_copy)
 
         modified_copy_2 = copy.deepcopy(valid_obj)
@@ -48,7 +48,7 @@ class ExtraPropertiesTest(unittest.TestCase):
             # KeyError on 'title' will only be raised if there is an error in extraProperties
             del child["title"]
             del child["extraProperties"][1]
-        with self.assertRaises(Exception):
+        with self.assertRaises(KeyError):
             validate_non_schema_required(modified_copy_2)
 
     def test_conp_status_values(self):


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
The current pre-commit config as some hook conflicting with each other.
This PR solves this issue by re-ordering the hooks in a non-conflicting way. This was tested by using a previous version of the repo (cab6b33dc9fdfdf2adf39fcecdc7b619baf8a13) and running the new configuration on it. The files auto-formatted now pass on the second execution.

Additionally this PR temporarily disable `mypy` and `pydocstyle` hooks while the code does not abide their rules yet. This in done in order to have the linting workflow succeed PRs.

## Related issues
#572 points out the issues with the current configuration.