### PR TITLE
[FIX] test suite failed to download authenticated datasets.

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import re
+import shutil
 import signal
 import subprocess
 from contextlib import contextmanager
@@ -144,7 +145,7 @@ def generate_datalad_provider(loris_api):
     os.makedirs(datalad_provider_path, exist_ok=True)
     with open(
         os.path.join(datalad_provider_path, "loris.cfg"),
-        "w+",
+        "w",
     ) as fout:
         fout.write(
             f"""[provider:loris]
@@ -208,6 +209,12 @@ def authenticate(dataset):
     zenodo_token = os.getenv(project + "_ZENODO_TOKEN", None)
 
     if username and password and loris_api:
+        # Delete the current credentials before adding new ones.
+        # This prevent datalad to keep the previous token when downloading files.
+        shutil.rmtree(
+            os.path.join(os.path.expanduser("~"), ".local", "share", "python_keyring"),
+            ignore_errors=True,
+        )
         keyring.set_password("datalad-loris", "user", username)
         keyring.set_password("datalad-loris", "password", password)
         generate_datalad_provider(loris_api)


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
The current test suite fails to download some authenticated datasets.
When Datalad download a file, it get the credential information from Python **keyring** module. In the current implementation, the username and password where written to the keyring database before downloading a restricted dataset.
This seemed to work for an initial dataset, however, subsequent one failed. This is because Datalad loads/stores a loris-token in the keyring. Therefore, subsequent restricted dataset where using the loris-token retrieve during the download of the first restricted dataset; resulting in invalid credentials.

To force Datalad to retrieve a new loris-token for every restricted datasets, this PR propose to delete the Python keyring database before adding new credentials.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
fixes #607; fixes #606; fixes #602