### PR TITLE
[FIX] CircleCI config to allow sub-modules installation in the build phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ jobs:
           command: |
             . ~/venv/bin/activate
             export PATH=~/git-annex.linux:$PATH
-            datalad install scripts/dats_validator/conp-dats
+            datalad install -r scripts
       - persist_to_workspace:
           root: *workdir
           paths:
-            - scripts/dats_validator/conp-dats
+            - scripts
 
   test:
     working_directory: *workdir


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
Currently, only the `scripts/dats_validator/conp-dats` sub-modules is installed during the build phase of the tests.
#640 demonstrates the issue with this approach.

This PR proposed to recursively install the `scripts` directory during the build phases. This should avoid further failure in the future when adding more sub-modules.