### PR TITLE
[FIX] Authentication for Zenodo datasets.

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -219,7 +219,7 @@ def authenticate(dataset):
         keyring.set_password("datalad-loris", "password", password)
         generate_datalad_provider(loris_api)
     elif zenodo_token:
-        pass
+        os.environ["DATALAD_ZENODO_token"] = zenodo_token
     elif is_authentication_required(dataset):
         if os.getenv("CIRCLE_PR_NUMBER", False):
             pytest.skip(


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This PR fix the authentication method for Zenodo restricted datasets in the test suite.
It takes the current `${DATASET}_ZENODO_TOKEN` secret and sets it to the expected `DATALAD_ZENODO_token` environment variable.

## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
#601