### PR TITLE
[FIX] archives were stored in the wrong location.

### DIFF
--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -135,8 +135,8 @@ def get_modified_datasets(
 def archive_dataset(
     dataset_path: str, out_dir: str, archive_name: str, version: str
 ) -> None:
-    os.makedirs(os.path.dirname(out_dir), mode=0o755, exist_ok=True)
-    out_filename = f"{archive_name}_version-{version}.tar.gz"
+    os.makedirs(out_dir, mode=0o755, exist_ok=True)
+    out_filename = os.path.join(out_dir, f"{archive_name}_version-{version}.tar.gz")
     logger.info(f"Archiving dataset: {dataset_path} to {out_filename}")
 
     cwd = os.getcwd()
@@ -222,7 +222,7 @@ if __name__ == "__main__":
                 )
                 archive_dataset(
                     dataset,
-                    out_dir=os.path.join(args.out_dir, dataset_name),
+                    out_dir=args.out_dir,
                     archive_name=archive_name,
                     version=version,
                 )


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This PR fix a bug introduced in #675 where the archives are not stored in the right location.
