### PR TITLE
[MODIFY] Only consider submodule as part of the /projects folder.

### DIFF
--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -68,6 +68,7 @@ def get_datasets_path():
     return {
         os.path.basename(submodule.path): submodule.path
         for submodule in git.Repo().submodules
+        if submodule.path.startswith("projects")
     }
 
 


### PR DESCRIPTION
## Description
<!--- A clear and concise description of what the dataset is. -->
This PR modify the auto archiving script to only update the submodules under the `/projects` path; i.e. datasets.