### PR TITLE
Test to see if that fixes the test failure reported in 697

### DIFF
--- a/tests/template.py
+++ b/tests/template.py
@@ -48,7 +48,7 @@ class Template:
             )
 
     def test_has_valid_dats(self, dataset):
-        
+
         # skip DATS tests for retrospectively crawled datasets
         if dataset in RETROSPECTIVE_CRAWLED_DATASET_LIST:
             return

--- a/tests/template.py
+++ b/tests/template.py
@@ -48,6 +48,10 @@ class Template:
             )
 
     def test_has_valid_dats(self, dataset):
+        
+        # skip DATS tests for retrospectively crawled datasets
+        if dataset in RETROSPECTIVE_CRAWLED_DATASET_LIST:
+            return
 
         with open(os.path.join(dataset, "DATS.json"), "rb") as f:
             json_obj = json.load(f)
@@ -88,18 +92,16 @@ class Template:
                 )
                 pytest.fail(summary_error_message, pytrace=False)
 
-            # If the dataset is not one of the retrospective crawled dataset,
-            # perform the extra validation checks
-            if dataset not in RETROSPECTIVE_CRAWLED_DATASET_LIST:
-                is_valid, errors = validate_non_schema_required(json_obj)
-                if not is_valid:
-                    summary_error_message = (
-                        f"Dataset {dataset} contains DATS.json that has errors "
-                        f"in required extra properties or formats. List of errors:\n"
-                    )
-                    for i, error_message in enumerate(errors, 1):
-                        summary_error_message += f"- {i}. {error_message}\n"
-                    pytest.fail(summary_error_message, pytrace=False)
+            # Perform the extra validation checks
+            is_valid, errors = validate_non_schema_required(json_obj)
+            if not is_valid:
+                summary_error_message = (
+                    f"Dataset {dataset} contains DATS.json that has errors "
+                    f"in required extra properties or formats. List of errors:\n"
+                )
+                for i, error_message in enumerate(errors, 1):
+                    summary_error_message += f"- {i}. {error_message}\n"
+                pytest.fail(summary_error_message, pytrace=False)
 
     def test_download(self, dataset):
         eval_config(dataset)


### PR DESCRIPTION
## Description

In PR #697, several datasets that were crawled by OSF or Zenodo failed the tests after updating the conp-dats submodule. This PR should be able to fix the issues flagged by the tests for the retrospective OSF datasets that do not have a distribution->formats field.

Suggestion was to completely skip the DATS tests for those retrospective datasets until we get a chance to contact the authors of the datasets so that their DATS files can be fixed.

