### PR TITLE
Uninstall a dataset once the archive has been created

### DIFF
--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -228,6 +228,9 @@ if __name__ == "__main__":
                         archive_name=archive_name,
                         version=version,
                     )
+                    # to save space on the VM that archives the dataset, need to uninstall
+                    # the datalad dataset. `datalad drop` does not free up enough space
+                    # unfortunately. See https://github.com/datalad/datalad/issues/6009
                     uninstall_dataset(dataset)
                     logger.info(f"SUCCESS: archive created for {dataset}")
                 else:

--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -12,6 +12,7 @@ import humanfriendly
 from datalad.plugin import export_archive
 from github import Github
 
+from scripts.datalad_utils import drop_dataset
 from scripts.datalad_utils import get_dataset
 from scripts.datalad_utils import install_dataset
 from scripts.log import get_logger
@@ -227,7 +228,7 @@ if __name__ == "__main__":
                         archive_name=archive_name,
                         version=version,
                     )
-                    os.system(f"git annex drop --all {dataset}")
+                    drop_dataset(dataset)
                     logger.info(f"SUCCESS: archive created for {dataset}")
                 else:
                     logger.info(f"SKIPPED: {dataset} larger than {args.max_size} GB")

--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -12,9 +12,9 @@ import humanfriendly
 from datalad.plugin import export_archive
 from github import Github
 
-from scripts.datalad_utils import uninstall_dataset
 from scripts.datalad_utils import get_dataset
 from scripts.datalad_utils import install_dataset
+from scripts.datalad_utils import uninstall_dataset
 from scripts.log import get_logger
 from tests.functions import get_proper_submodules
 

--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -12,7 +12,7 @@ import humanfriendly
 from datalad.plugin import export_archive
 from github import Github
 
-from scripts.datalad_utils import drop_dataset
+from scripts.datalad_utils import uninstall_dataset
 from scripts.datalad_utils import get_dataset
 from scripts.datalad_utils import install_dataset
 from scripts.log import get_logger
@@ -228,7 +228,7 @@ if __name__ == "__main__":
                         archive_name=archive_name,
                         version=version,
                     )
-                    drop_dataset(dataset)
+                    uninstall_dataset(dataset)
                     logger.info(f"SUCCESS: archive created for {dataset}")
                 else:
                     logger.info(f"SKIPPED: {dataset} larger than {args.max_size} GB")

--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -227,6 +227,7 @@ if __name__ == "__main__":
                         archive_name=archive_name,
                         version=version,
                     )
+                    os.system(f"git annex drop --all {dataset}")
                     logger.info(f"SUCCESS: archive created for {dataset}")
                 else:
                     logger.info(f"SKIPPED: {dataset} larger than {args.max_size} GB")

--- a/scripts/datalad_utils.py
+++ b/scripts/datalad_utils.py
@@ -14,6 +14,10 @@ class DownloadFailed(Exception):
     pass
 
 
+class DropFailed(Exception):
+    pass
+
+
 def retry(max_attempt):
     def decorator(func):
         @functools.wraps(func)
@@ -61,3 +65,24 @@ def get_dataset(dataset_path: str, *, recursive: bool = False) -> None:
         _get_dataset(dataset_path, recursive=recursive)
     except Exception as e:
         raise DownloadFailed(f"Download failed for dataset: {dataset_path}\n{e}")
+
+
+@retry(max_attempt=3)
+def _drop_dataset(dataset_path: str, *, recursive: bool = False) -> None:
+    full_path = os.path.join(os.getcwd(), dataset_path)
+    datalad.api.drop(path=full_path, recursive=recursive, on_failure="stop")
+
+
+def drop_dataset(dataset_path: str, *, recursive: bool = False) -> None:
+    # Git annex drop command needed to remove all leftover file data under
+    # .git/annex/objects even after running datalad drop...
+    # See https://github.com/datalad/datalad/issues/6009
+    cwd = os.getcwd
+    try:
+        _drop_dataset(dataset_path, recursive=recursive)
+        os.chdir(os.path.join(cwd, dataset_path))
+        os.system(f"git annex drop --all")
+    except Exception as e:
+        raise DropFailed(f"File drop failed for dataset: {dataset_path}\n{e}")
+    finally:
+        os.chdir(cwd)

--- a/scripts/datalad_utils.py
+++ b/scripts/datalad_utils.py
@@ -18,6 +18,10 @@ class DropFailed(Exception):
     pass
 
 
+class UninstallFailed(Exception):
+    pass
+
+
 def retry(max_attempt):
     def decorator(func):
         @functools.wraps(func)
@@ -65,6 +69,19 @@ def get_dataset(dataset_path: str, *, recursive: bool = False) -> None:
         _get_dataset(dataset_path, recursive=recursive)
     except Exception as e:
         raise DownloadFailed(f"Download failed for dataset: {dataset_path}\n{e}")
+
+
+@retry(max_attempt=3)
+def _uninstall_dataset(dataset_path: str, *, recursive: bool = False):
+    full_path = os.path.join(os.getcwd(), dataset_path)
+    datalad.api.uninstall(path=full_path, recursive=recursive, on_failure="stop")
+
+
+def uninstall_dataset(dataset_path: str, *, recursive: bool = False) -> None:
+    try:
+        _uninstall_dataset(dataset_path, recursive=recursive)
+    except Exception as e:
+        raise UninstallFailed(f"Installation failed for dataset: {dataset_path}\n{e}")
 
 
 @retry(max_attempt=3)


### PR DESCRIPTION
## Description

Because some datasets to archive are actually quite large, disk space gets quickly filled up. Once an archive is created, the auto-archive script will uninstall the DataLad dataset that has been archive to manage space better on the server.

Note: initially tried with `datalad drop` but realized quickly that it did not really free up space on the server so instead, we have to run `datalad uninstall`. See https://github.com/datalad/datalad/issues/6009 created on the DataLad GitHub repo.