### PR TITLE
If derivedFrom field is populated in DATS file, automatically add the raw dataset to the datalad repo

### DIFF
--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -279,6 +279,7 @@ class BaseCrawler:
                         print(f"Found existing DATS.json at {existing_dats_path}")
                     if existing_dats_path != dats_path:
                         os.rename(existing_dats_path, dats_path)
+                    self._add_source_data_submodule_if_derivedfrom_conp_dataset(dats_path)
                 else:
                     self._create_new_dats(
                         dataset_dir,
@@ -552,3 +553,20 @@ Functional checks:
                         return os.path.join(file_path, subfile_name)
             elif file_name.lower() == "dats.json":
                 return file_path
+
+    def _add_source_data_submodule_if_derivedfrom_conp_dataset(self, dats_json):
+        f = open(dats_json, 'r')
+        metadata = json.loads(f.read())
+        f.close()
+
+        source_dataset_link = None
+        source_dataset_id = None
+        for property in metadata['extraProperties']:
+            if property['category'] == 'derivedFrom':
+                source_dataset_link = property['values'][0]['value']
+            if property['category'] == 'parent_dataset_id':
+                source_dataset_id = property['values'][0]['value']
+
+        if 'github.com' in source_dataset_link:
+            d = self.datalad.Dataset(os.path.join(dataset_dir, source_dataset_id))
+            d.create()

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -559,7 +559,9 @@ Functional checks:
             elif file_name.lower() == "dats.json":
                 return file_path
 
-    def _add_source_data_submodule_if_derivedfrom_conp_dataset(self, dats_json, dataset_dir):
+    def _add_source_data_submodule_if_derivedfrom_conp_dataset(
+            self, dats_json, dataset_dir
+    ):
         f = open(dats_json)
         metadata = json.loads(f.read())
         f.close()

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -280,7 +280,7 @@ class BaseCrawler:
                     if existing_dats_path != dats_path:
                         os.rename(existing_dats_path, dats_path)
                     self._add_source_data_submodule_if_derivedfrom_conp_dataset(
-                        dats_path
+                        dats_path, dataset_dir
                     )
                 else:
                     self._create_new_dats(
@@ -323,7 +323,7 @@ class BaseCrawler:
                         if existing_dats_path != dats_path:
                             os.rename(existing_dats_path, dats_path)
                         self._add_source_data_submodule_if_derivedfrom_conp_dataset(
-                            dats_path
+                            dats_path, dataset_dir
                         )
                     else:
                         self._create_new_dats(
@@ -559,7 +559,7 @@ Functional checks:
             elif file_name.lower() == "dats.json":
                 return file_path
 
-    def _add_source_data_submodule_if_derivedfrom_conp_dataset(self, dats_json):
+    def _add_source_data_submodule_if_derivedfrom_conp_dataset(self, dats_json, dataset_dir):
         f = open(dats_json)
         metadata = json.loads(f.read())
         f.close()

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -570,17 +570,17 @@ Functional checks:
         if "extraProperties" not in metadata.keys():
             return
         for property in metadata["extraProperties"]:
-            if "values" not in property.keys():
-                continue
-            if type(property["values"]) != list:
-                continue
-            if "value" not in property["values"][0].keys():
-                continue
             if property["category"] == "derivedFrom":
-                source_dataset_link = property["values"][0]["value"]
+                try:
+                    source_dataset_link = property["values"][0]["value"]
+                except (KeyError, IndexError):
+                    continue
             if property["category"] == "parent_dataset_id":
-                source_dataset_id = property["values"][0]["value"]
+                try:
+                    source_dataset_id = property["values"][0]["value"]
+                except (KeyError, IndexError):
+                    continue
 
-        if source_dataset_link and "github.com" in source_dataset_link:
+        if source_dataset_link is not None and "github.com" in source_dataset_link:
             d = self.datalad.Dataset(os.path.join(dataset_dir, source_dataset_id))
             d.create()

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -560,7 +560,7 @@ Functional checks:
                 return file_path
 
     def _add_source_data_submodule_if_derivedfrom_conp_dataset(
-            self, dats_json, dataset_dir
+        self, dats_json, dataset_dir
     ):
         f = open(dats_json)
         metadata = json.loads(f.read())

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -570,7 +570,7 @@ Functional checks:
             if property["category"] == "derivedFrom":
                 source_dataset_link = property["values"][0]["value"]
             if property["category"] == "parent_dataset_id":
-                source_dataset_id = property['values'][0]["value"]
+                source_dataset_id = property["values"][0]["value"]
 
         if "github.com" in source_dataset_link:
             d = self.datalad.Dataset(os.path.join(dataset_dir, source_dataset_id))

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -279,7 +279,9 @@ class BaseCrawler:
                         print(f"Found existing DATS.json at {existing_dats_path}")
                     if existing_dats_path != dats_path:
                         os.rename(existing_dats_path, dats_path)
-                    self._add_source_data_submodule_if_derivedfrom_conp_dataset(dats_path)
+                    self._add_source_data_submodule_if_derivedfrom_conp_dataset(
+                        dats_path
+                    )
                 else:
                     self._create_new_dats(
                         dataset_dir,
@@ -320,6 +322,9 @@ class BaseCrawler:
                             print(f"Found existing DATS.json at {existing_dats_path}")
                         if existing_dats_path != dats_path:
                             os.rename(existing_dats_path, dats_path)
+                        self._add_source_data_submodule_if_derivedfrom_conp_dataset(
+                            dats_path
+                        )
                     else:
                         self._create_new_dats(
                             dataset_dir,
@@ -555,18 +560,18 @@ Functional checks:
                 return file_path
 
     def _add_source_data_submodule_if_derivedfrom_conp_dataset(self, dats_json):
-        f = open(dats_json, 'r')
+        f = open(dats_json)
         metadata = json.loads(f.read())
         f.close()
 
         source_dataset_link = None
         source_dataset_id = None
-        for property in metadata['extraProperties']:
-            if property['category'] == 'derivedFrom':
-                source_dataset_link = property['values'][0]['value']
-            if property['category'] == 'parent_dataset_id':
-                source_dataset_id = property['values'][0]['value']
+        for property in metadata["extraProperties"]:
+            if property["category"] == "derivedFrom":
+                source_dataset_link = property["values"][0]["value"]
+            if property["category"] == "parent_dataset_id":
+                source_dataset_id = property['values'][0]["value"]
 
-        if 'github.com' in source_dataset_link:
+        if "github.com" in source_dataset_link:
             d = self.datalad.Dataset(os.path.join(dataset_dir, source_dataset_id))
             d.create()

--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -562,7 +562,7 @@ Functional checks:
     def _add_source_data_submodule_if_derived_from_conp_dataset(
         self, dats_json, dataset_dir
     ):
-        with open(dats_json, "r") as f:
+        with open(dats_json) as f:
             metadata = json.loads(f.read())
 
         source_dataset_link = None


### PR DESCRIPTION
## Description

This modifies the base crawler pipeline to read the DATS.json file of the crawled dataset and check whether there is an 'derivedFrom' entry in the extra properties. If there is one, then add the source dataset as a submodule to the crawled dataset.

## Related issues 

#701 