### PR TITLE
Add 'subjects' metadata from Zenodo API to 'isAbout' field in DATS model

### DIFF
--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -139,6 +139,17 @@ class ZenodoCrawler(BaseCrawler):
             if "keywords" in metadata.keys():
                 keywords = list(map(lambda x: {"value": x}, metadata["keywords"]))
 
+            # Retrieve subject and clean subject to insert in isAbout of DATS file
+            is_about = []
+            if 'subjects' in metadata.keys():
+                for subject in metadata["subjects"]:
+                    is_about.append(
+                        {
+                            "identifier": {"identifier": subject["identifier"]},
+                            "name": subject["term"]
+                        }
+                    )
+
             dataset_size, dataset_unit = humanize.naturalsize(
                 sum([filename["size"] for filename in files]),
             ).split(" ")

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -143,11 +143,10 @@ class ZenodoCrawler(BaseCrawler):
             # Retrieve subject annotations from Zenodo and clean the annotated
             # subjects to insert in isAbout of DATS file
             is_about = []
-            species_identifier_source_base_url = "www.ncbi.nlm.nih.gov/taxonomy"
             if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
                     if re.match(
-                        species_identifier_source_base_url, subject["identifier"]
+                        "www.ncbi.nlm.nih.gov/taxonomy", subject["identifier"]
                     ):
                         is_about.append(
                             {

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -144,11 +144,13 @@ class ZenodoCrawler(BaseCrawler):
             species_identifier_source_base_url = "www.ncbi.nlm.nih.gov/taxonomy"
             if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
-                    if re.match(species_identifier_source_base_url, subject["identifier"]):
+                    if re.match(
+                            species_identifier_source_base_url, subject["identifier"]
+                    ):
                         is_about.append(
                             {
                                 "identifier": {"identifier": subject["identifier"]},
-                                "name": subject["term"],
+                                "name": subject["term"]
                             }
                         )
                     else:

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -145,9 +145,7 @@ class ZenodoCrawler(BaseCrawler):
             is_about = []
             if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
-                    if re.match(
-                        "www.ncbi.nlm.nih.gov/taxonomy", subject["identifier"]
-                    ):
+                    if re.match("www.ncbi.nlm.nih.gov/taxonomy", subject["identifier"]):
                         is_about.append(
                             {
                                 "identifier": {"identifier": subject["identifier"]},

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -145,19 +145,19 @@ class ZenodoCrawler(BaseCrawler):
             if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
                     if re.match(
-                            species_identifier_source_base_url, subject["identifier"]
+                        species_identifier_source_base_url, subject["identifier"]
                     ):
                         is_about.append(
                             {
                                 "identifier": {"identifier": subject["identifier"]},
-                                "name": subject["term"]
+                                "name": subject["term"],
                             }
                         )
                     else:
                         is_about.append(
                             {
                                 "valueIRI": subject["identifier"],
-                                "value": subject["term"]
+                                "value": subject["term"],
                             }
                         )
 

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -141,12 +141,12 @@ class ZenodoCrawler(BaseCrawler):
 
             # Retrieve subject and clean subject to insert in isAbout of DATS file
             is_about = []
-            if 'subjects' in metadata.keys():
+            if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
                     is_about.append(
                         {
                             "identifier": {"identifier": subject["identifier"]},
-                            "name": subject["term"]
+                            "name": subject["term"],
                         }
                     )
 

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import re
 from typing import Callable
 
 import html2markdown
@@ -139,7 +140,8 @@ class ZenodoCrawler(BaseCrawler):
             if "keywords" in metadata.keys():
                 keywords = list(map(lambda x: {"value": x}, metadata["keywords"]))
 
-            # Retrieve subject annotations from Zenodo and clean the annotated subjects to insert in isAbout of DATS file
+            # Retrieve subject annotations from Zenodo and clean the annotated
+            # subjects to insert in isAbout of DATS file
             is_about = []
             species_identifier_source_base_url = "www.ncbi.nlm.nih.gov/taxonomy"
             if "subjects" in metadata.keys():

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -141,14 +141,23 @@ class ZenodoCrawler(BaseCrawler):
 
             # Retrieve subject and clean subject to insert in isAbout of DATS file
             is_about = []
+            species_identifier_source_base_url = "www.ncbi.nlm.nih.gov/taxonomy"
             if "subjects" in metadata.keys():
                 for subject in metadata["subjects"]:
-                    is_about.append(
-                        {
-                            "identifier": {"identifier": subject["identifier"]},
-                            "name": subject["term"],
-                        }
-                    )
+                    if re.match(species_identifier_source_base_url, subject["identifier"]):
+                        is_about.append(
+                            {
+                                "identifier": {"identifier": subject["identifier"]},
+                                "name": subject["term"],
+                            }
+                        )
+                    else:
+                        is_about.append(
+                            {
+                                "valueIRI": subject["identifier"],
+                                "value": subject["term"]
+                            }
+                        )
 
             dataset_size, dataset_unit = humanize.naturalsize(
                 sum([filename["size"] for filename in files]),

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -267,7 +267,7 @@ def validate_is_about(dataset):
     if "isAbout" in dataset.keys():
         species_present = False
         for entry in dataset["isAbout"]:
-            if "identifier" in entry.keys():
+            if "identifier" in entry.keys() and "identifierSource" in entry["identifier"].keys():
                 identifier_source = entry["identifier"]["identifierSource"].lower()
                 if identifier_source.startswith(identifier_source_base_url):
                     species_present = True

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -267,7 +267,10 @@ def validate_is_about(dataset):
     if "isAbout" in dataset.keys():
         species_present = False
         for entry in dataset["isAbout"]:
-            if "identifier" in entry.keys() and "identifierSource" in entry["identifier"].keys():
+            if (
+                    "identifier" in entry.keys()
+                    and "identifierSource" in entry["identifier"].keys()
+            ):
                 identifier_source = entry["identifier"]["identifierSource"].lower()
                 if identifier_source.startswith(identifier_source_base_url):
                     species_present = True

--- a/scripts/dats_validator/validator.py
+++ b/scripts/dats_validator/validator.py
@@ -268,8 +268,8 @@ def validate_is_about(dataset):
         species_present = False
         for entry in dataset["isAbout"]:
             if (
-                    "identifier" in entry.keys()
-                    and "identifierSource" in entry["identifier"].keys()
+                "identifier" in entry.keys()
+                and "identifierSource" in entry["identifier"].keys()
             ):
                 identifier_source = entry["identifier"]["identifierSource"].lower()
                 if identifier_source.startswith(identifier_source_base_url):


### PR DESCRIPTION
## Description

This modifies the Zenodo crawler in order to fetch the `subjects` information present for a dataset API response and insert them into the `isAbout` field of the automatically generated `DATS.json` file.

Example of the what a DATS `isAbout` would look like once automatically generated:
```
"isAbout": [
        {
            "identifier": {
                "identifier": "http://uri.interlex.org/base/ilx_0106458"
            },    
            "name": "Magnetic resonance imaging"
        },        
        {
            "identifier": {
                "identifier": "http://uri.interlex.org/base/ilx_0110407"
            }, 
            "name": "Schizophrenia"
        }
    ],
```

Note: the validator needed a quick fix as well to not crash on such DATS files.

## Related issues

Resolves #677