### PR TITLE
Update the DATS context submodule

### DIFF
--- a/tests/test_dats_annotator.py
+++ b/tests/test_dats_annotator.py
@@ -91,6 +91,9 @@ def dats_jsonld_dataset_instance():
             "DatasetDistribution": "sdo:DataDownload",
             "distributions": {"@id": "sdo:distribution", "@type": "sdo:DataDownload"},
             "Dataset": "sdo:Dataset",
+            "keywords": {"@id": "sdo:keywords", "@type": "sdo:Thing"},
+            "version": {"@id": "sdo:version", "@type": "sdo:Thing"},
+            "types": {"@id": "sdo:identifier", "@type": "sdo:Thing"},
         },
     }
 


### PR DESCRIPTION
The CONP DATS schema is used as a submodule for the DATS annotator. This PR updates the submodule in order to include the recent schema extensions. A test fixture also had to be updated to match the updated schema.

This came up in #708 