### PR TITLE
updating MICA-MICS logo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -184,7 +184,6 @@
 [submodule "projects/mousebytesdataset"]
 	path = projects/mousebytesdataset
 	url = https://github.com/conpdatasets/mousebytesdataset.git
-
 [submodule "projects/mousebytes/MB-Cholinergic-deficient-mouse-model"]
 	path = projects/mousebytes/MB-Cholinergic-deficient-mouse-model
 	url = https://github.com/conpdatasets/MB-Cholinergic-deficient-mouse-model.git
@@ -193,4 +192,4 @@
 	url = https://github.com/conpdatasets/MB-Co-transmission-of-cholinergic-interneurons.git
 [submodule "projects/mousebytes/MB-Heterogenous-task-representative-data"]
 	path = projects/mousebytes/MB-Heterogenous-task-representative-data
-	url = https://github.com/conpdatasets/MB-Heterogenous-task-representative-data
+	url = https://github.com/conpdatasets/MB-Heterogenous-task-representative-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -191,3 +191,6 @@
 [submodule "projects/mousebytes/MB-Co-transmission-of-cholinergic-interneurons"]
 	path = projects/mousebytes/MB-Co-transmission-of-cholinergic-interneurons
 	url = https://github.com/conpdatasets/MB-Co-transmission-of-cholinergic-interneurons.git
+[submodule "projects/mousebytes/MB-Heterogenous-task-representative-data"]
+	path = projects/mousebytes/MB-Heterogenous-task-representative-data
+	url = https://github.com/conpdatasets/MB-Heterogenous-task-representative-data


### PR DESCRIPTION
This PR updates the `DATS.json` file in the `MICA-MICS` dataset to connect to a local copy of their logo. [ Replacing previous content that was garbled by an error in branch management. ]