### PR TITLE
Adding new MouseBytes dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -193,3 +193,6 @@
 [submodule "projects/mousebytes/MB-Co-transmission-of-cholinergic-interneurons"]
 	path = projects/mousebytes/MB-Co-transmission-of-cholinergic-interneurons
 	url = https://github.com/conpdatasets/MB-Co-transmission-of-cholinergic-interneurons.git
+[submodule "projects/mousebytes/MB-Heterogenous-task-representative-data"]
+	path = projects/mousebytes/MB-Heterogenous-task-representative-data
+	url = https://github.com/conpdatasets/MB-Heterogenous-task-representative-data


### PR DESCRIPTION
This PR replaces https://github.com/CONP-PCNO/conp-dataset/pull/717, linking to a local copy of the dataset rather than the source repository.