### PR TITLE
Remove trailing \n from the date read from .conp-archive

### DIFF
--- a/scripts/auto_archive.py
+++ b/scripts/auto_archive.py
@@ -99,7 +99,7 @@ def get_modified_datasets(
     if since is None:
         if os.path.exists(".conp-archive"):
             with open(".conp-archive") as fin:
-                since = datetime.fromisoformat(fin.read())
+                since = datetime.fromisoformat(fin.read().rstrip("\n"))
         else:
             since = now - timedelta(weeks=1)
 


### PR DESCRIPTION
## Description

This fixes the following error when reading the date the archiver was last executed from .conp-archive:

```
Traceback (most recent call last):
  File "/data/conp-dataset/./scripts/auto_archive.py", line 179, in <module>
    modified_datasets = get_modified_datasets()
  File "/data/conp-dataset/./scripts/auto_archive.py", line 102, in get_modified_datasets
    since = datetime.fromisoformat(fin.read())
ValueError: Invalid isoformat string: '2022-03-01T14:56:46.961875-04:00\n'
```