### PR TITLE
adding braincode epilepsy dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,3 +217,6 @@
 [submodule "projects/braincode_POND_Registry_Imaging_Data_Release"]
 	path = projects/braincode_POND_Registry_Imaging_Data_Release
 	url = https://github.com/conpdatasets/braincode_POND_Registry_Imaging_Data_Release
+[submodule "projects/braincode_Epilepsy_Priority_Setting_Partnership"]
+	path = projects/braincode_Epilepsy_Priority_Setting_Partnership
+	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -219,4 +219,4 @@
 	url = https://github.com/conpdatasets/braincode_POND_Registry_Imaging_Data_Release
 [submodule "projects/braincode_Epilepsy_Priority_Setting_Partnership"]
 	path = projects/braincode_Epilepsy_Priority_Setting_Partnership
-	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership.git
+	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership

--- a/.gitmodules
+++ b/.gitmodules
@@ -218,3 +218,6 @@
 	path = projects/braincode_POND_Registry_Imaging_Data_Release
 	url = https://github.com/conpdatasets/braincode_POND_Registry_Imaging_Data_Release
 
+[submodule "projects/braincode_Epilepsy_Priority_Setting_Partnership"]
+	path = projects/braincode_Epilepsy_Priority_Setting_Partnership
+	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership

--- a/.gitmodules
+++ b/.gitmodules
@@ -217,6 +217,4 @@
 [submodule "projects/braincode_POND_Registry_Imaging_Data_Release"]
 	path = projects/braincode_POND_Registry_Imaging_Data_Release
 	url = https://github.com/conpdatasets/braincode_POND_Registry_Imaging_Data_Release
-[submodule "projects/braincode_Epilepsy_Priority_Setting_Partnership"]
-	path = projects/braincode_Epilepsy_Priority_Setting_Partnership
-	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -217,7 +217,6 @@
 [submodule "projects/braincode_POND_Registry_Imaging_Data_Release"]
 	path = projects/braincode_POND_Registry_Imaging_Data_Release
 	url = https://github.com/conpdatasets/braincode_POND_Registry_Imaging_Data_Release
-
 [submodule "projects/braincode_Epilepsy_Priority_Setting_Partnership"]
 	path = projects/braincode_Epilepsy_Priority_Setting_Partnership
 	url = https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership


### PR DESCRIPTION
This PR adds the https://github.com/conpdatasets/braincode_Epilepsy_Priority_Setting_Partnership dataset to conp-dataset.