### PR TITLE
Fix pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
       - id: dockerfilelint
         stages: [commit]
   # Style
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]

--- a/scripts/conp_to_nidm_terms/template.jsonld
+++ b/scripts/conp_to_nidm_terms/template.jsonld
@@ -1,10 +1,10 @@
 {
   "@context": "https://raw.githubusercontent.com/NIDM-Terms/terms/master/context/cde_context.jsonld",
   "@type": "http://www.w3.org/2002/07/owl#DatatypeProperty",
-  "label": "",
   "associatedWith": [
     "DATS"
   ],
+  "label": "",
   "sameAs": "",
   "valueType": "xsd:string"
 }

--- a/scripts/dats_jsonld_annotator/annotator.py
+++ b/scripts/dats_jsonld_annotator/annotator.py
@@ -201,7 +201,7 @@ def gen_jsonld_outpath(dats_json_f, out_path):
     if out_path.is_dir():
         dats_jsonld_f = out_path / out_name
     else:
-        raise Exception(
+        raise ValueError(
             f"{out_path = } for {dats_json_f.resolve()} is not a path to a file or directory. "
             f"I don't know where to store the output. "
             f"Please provide a valid path with the --out flag."

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -9,11 +9,11 @@ from contextlib import contextmanager
 from functools import reduce
 
 import datalad.api as api
-from datalad.support.annexrepo import AnnexRepo
 import git
 import humanize
 import keyring
 import pytest
+from datalad.support.annexrepo import AnnexRepo
 from git.exc import InvalidGitRepositoryError
 
 

--- a/tests/test_dats_annotator.py
+++ b/tests/test_dats_annotator.py
@@ -177,7 +177,7 @@ class TestGenerateJsonldPath:
         # Then we want this to error out here
         # We only create output directories at the start
         out_path = tmp_path / "nonexistent"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             gen_jsonld_outpath(dats_path, out_path)
 
     def test_output_path_is_none(self, tmp_path, dats_path):
@@ -199,7 +199,7 @@ class TestGenerateJsonldPath:
 
     def test_output_dir_fails(self, tmp_path, dats_path):
         out_path = tmp_path / "some" / "arbitrary" / "path"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             gen_jsonld_outpath(dats_path, out_path)
 
 


### PR DESCRIPTION
## Description

The "pre-commit hooks" GitHub action fails because the flake8 pre-commit hook is misspecified. This fixes that issue and incorporates the results of `pre-commit run --all-files`, and a minor change to the json-ld annotator, making the exception raised slightly more specific to satisfy flake8.
