### PR TITLE
Allow missing newline at EOF for git config files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
+        exclude: '.*(\.gitmodules|\.datalad/config|\.gitattributes)$'
       - id: check-executables-have-shebangs
   # Disable until a stable version of type annotation is out.
   # - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
## Description

This is a first attempt at solving #782. The pre-commit config is the only place I could find that checks for a newline at EOF, and I couldn't find a mechanism for the pre-commit to apply to subdatasets, so I'm not really confident that this will have the intended effect for subdatasets.

I have verified that it works for the root dataset, and if someone could point me at an instance of this issue causing problems, I could double check that this will work in that case.

## Checklist
<!--- Task to do for an approval of the pull request -->

Mandatory files and elements:
- [ ] A `README.md` file, at the root of the dataset
- [ ] A `DATS.json` file, at the root of the dataset
- [ ] If configuration is required (for instance to enable a special remote), a `config.sh` script at the root of the dataset
- [ ] A DOI (see instructions in [contribution guide](https://github.com/CONP-PCNO/conp-dataset/blob/master/.github/CONTRIBUTING.md), and corresponding badge in `README.md`

Functional checks:
- [ ] Dataset can be installed using DataLad, recursively if it has sub-datasets
- [ ] Every data file has a URL
- [ ] Every data file can be retrieved or requires authentication
- [ ] `DATS.json` is a valid DATs model
- [ ] If dataset is derived data, raw data is a sub-dataset


## Related issues (optional)
<!--- Link to issues that would be solved with this pull request -->
