### PR TITLE
Add updated copy of Taowu dataset hosted at sftp.conp.ca

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -224,3 +224,6 @@
 [submodule "projects/refseq/refseq_Mus_musculus"]
 	path = projects/refseq/refseq_Mus_musculus
 	url = https://github.com/conpdatasets/refseq_Mus_musculus.git
+[submodule "projects/Taowu_local"]
+	path = projects/Taowu_local
+	url = https://github.com/conpdatasets/Taowu_local

--- a/.gitmodules
+++ b/.gitmodules
@@ -223,3 +223,6 @@
 [submodule "projects/refseq/refseq_Mus_musculus"]
 	path = projects/refseq/refseq_Mus_musculus
 	url = https://github.com/conpdatasets/refseq_Mus_musculus
+[submodule "projects/Taowu"]
+	path = projects/Taowu
+	url = https://github.com/conpdatasets/Taowu

--- a/.gitmodules
+++ b/.gitmodules
@@ -220,10 +220,6 @@
 [submodule "projects/braincode_EpLink"]
 	path = projects/braincode_EpLink
 	url = https://github.com/CONP-PCNO/braincode_EpLink
-
 [submodule "projects/refseq/refseq_Mus_musculus"]
 	path = projects/refseq/refseq_Mus_musculus
-	url = https://github.com/conpdatasets/refseq_Mus_musculus.git
-[submodule "projects/Taowu_local"]
-	path = projects/Taowu_local
-	url = https://github.com/conpdatasets/Taowu_local
+	url = https://github.com/conpdatasets/refseq_Mus_musculus

--- a/.gitmodules
+++ b/.gitmodules
@@ -193,9 +193,6 @@
 [submodule "projects/mousebytes/MB-Heterogenous-task-representative-data"]
 	path = projects/mousebytes/MB-Heterogenous-task-representative-data
 	url = https://github.com/conpdatasets/MB-Heterogenous-task-representative-data.git
-[submodule "projects/Taowu"]
-	path = projects/Taowu
-	url = https://github.com/conpdatasets/Taowu.git
 [submodule "projects/Neurocon"]
 	path = projects/Neurocon
 	url = https://github.com/conpdatasets/Neurocon.git

--- a/scripts/sftp-crawler.pl
+++ b/scripts/sftp-crawler.pl
@@ -52,5 +52,3 @@ while ($inline = <IN_LARGE>) {
 close IN_LARGE;
 
 exit();
-
-

--- a/scripts/sftp-crawler.pl
+++ b/scripts/sftp-crawler.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+#
+#  sftp_crawler.pl - crawl a dataset on sftp-conp.acelab.ca
+#                    - EOB - Mar 03 2020 - reworked Apr 21 2022
+#
+# usage: sftp_crawler.pl $local_projectname $username $password $local_directory $remote_directory $inlist
+#
+#    see https://github.com/CONP-PCNO/conp-documentation/blob/master/Developers-Notes/CONP_VM_setups_and_maintenance/SFTP_community_server/CONP_data_upload_admin.md for details
+#
+#
+########################################
+
+# use lib '/home/eaobrien/perl5/lib/perl5/x86_64-linux-gnu-thread-multi';
+use Net::SFTP::Foreign;
+use Net::SFTP::Foreign::Attributes;
+use Net::SFTP::Foreign::Constants qw(:error :status);
+
+my $username          = $ARGV[0];
+my $password          = $ARGV[1];
+my $local_directory   = $ARGV[2];
+my $remote_directory  = $ARGV[3];
+my $inlist            = $ARGV[4];
+
+my $remote_host      = "sftp.conp.ca";
+
+my $sftp_connection = Net::SFTP::Foreign->new($remote_host,user=>$username,password=>$password, port=>"7500");
+
+my $inline       = "";
+my $remote_file  = "";
+my $local_file   = "";
+
+
+open(IN_LARGE, "$inlist") || die "Can't open $inlist to read";
+
+while ($inline = <IN_LARGE>) {
+    chomp $inline;
+    $remote_file = $inline;
+	$local_file  = $remote_file;
+    $remote_file =~ s/data\/proftpd\///;
+	$local_file  =~ s/$remote_directory/$local_directory/;
+    $local_file =~ s/\/data\/proftpd\/users\/$username//;
+
+	$remote_file = "https://".$remote_host.$remote_file;
+#	print "linking $remote_file as $local_file\n";
+	unless (-e $local_file) {  # do not regenerate files that already exist (for case of interrupted crawl)
+    	system "git annex addurl $remote_file --file $local_file";
+	}
+	else {
+		print "$local_file already exists\n";
+	}
+}
+close IN_LARGE;
+
+exit();
+
+


### PR DESCRIPTION
This PR replaces the previous `Taowu` dataset, which had been giving download failures, with `Taowu_local`, the same content hosted on `sftp.conp.ca`.  It also adds an updated version of the crawling script `sftp-crawler.pl` to the `scripts` directory.