### PR TITLE
Test specifying branch in .gitmodules to address problem with transfer to live server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,3 @@
 [submodule "projects/cneuromod.processed"]
 	path = projects/cneuromod.processed
 	url = https://github.com/conpdatasets/cneuromod.processed
-[submodule "projects/AdolescentBrainDevelopment"]
-	path = projects/AdolescentBrainDevelopment
-	url = https://github.com/conpdatasets/AdolescentBrainDevelopment

--- a/.gitmodules
+++ b/.gitmodules
@@ -238,3 +238,7 @@
 [submodule "projects/cneuromod.processed"]
 	path = projects/cneuromod.processed
 	url = https://github.com/conpdatasets/cneuromod.processed
+[submodule "projects/AdolescentBrainDevelopment"]
+	path = projects/AdolescentBrainDevelopment
+	url = https://github.com/conpdatasets/AdolescentBrainDevelopment
+	branch = main


### PR DESCRIPTION
In this PR, the AdolescentBrainDevelopment subdataset has been removed and then re-added as a submodule with the `main` branch explicitly specified, to test whether this resolves the problem with `git checkout` default expecting updates on the `master` branch and not transferring them from the CONP-PCNO github repository to the live server when a `main' branch is involved.