### PR TITLE
Updating DATS.json for cbig-als with test registrationPage property

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,6 +232,7 @@
 [submodule "projects/cbig-als"]
 	path = projects/cbig-als
 	url = https://github.com/conpdatasets/cbig-als
+    branch = main
 [submodule "projects/cneuromod"]
 	path = projects/cneuromod
 	url = https://github.com/conpdatasets/cneuromod


### PR DESCRIPTION
This PR updates the cbig-als DATS.json file with a new field, extraProperties=>registrationPage.  It also changes the .gitmodules specification of this dataset, adding `branch=main` to address the issue of transfer to the portal.