### PR TITLE
temporary fix: removing Semantic_Encoding_Memory_Task

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -213,9 +213,6 @@
 	path = projects/AdolescentBrainDevelopment
 	url = https://github.com/conpdatasets/AdolescentBrainDevelopment
 	branch = main
-[submodule "/data/crawler/conp-dataset/projects/Semantic_Encoding_Memory_Task"]
-	path = /data/crawler/conp-dataset/projects/Semantic_Encoding_Memory_Task
-	url = https://github.com/conp-bot/conp-dataset-Semantic-Encoding-Memory-Task.git
 [submodule "projects/CIMA-Q"]
 	path = projects/CIMA-Q
 	url = https://github.com/conpdatasets/CIMA-Q


### PR DESCRIPTION
This PR removes the recently added `Semantic_Encoding_Memory_Task` dataset as a stopgap measure to address a Datalad installation problem apparently caused by concatenated lists of dataset names exceeding a length threshold.  This will fix the download functionality short-term.