### PR TITLE
removing superfluous blank line from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -549,7 +549,6 @@
 	path = projects/cneuromod_processed
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
-
 [submodule "/data/crawler/conp-dataset/projects/MICA_PNI__Precision_NeuroImaging_and_Connectomics"]
 	path = /data/crawler/conp-dataset/projects/MICA_PNI__Precision_NeuroImaging_and_Connectomics
 	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics.git


### PR DESCRIPTION
https://github.com/CONP-PCNO/conp-dataset/pull/923 added the new submodule link in `.gitmodules` after the linter-mandated terminal CR/LF rather than before, and this PR corrects that, against the possibility of this causing problems parsing the file subsequently.