### PR TITLE
Manually adding MICA_PNI dataset back

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -549,7 +549,6 @@
 	path = projects/cneuromod_processed
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
-
 [submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
 	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
 	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/

--- a/.gitmodules
+++ b/.gitmodules
@@ -549,6 +549,3 @@
 	path = projects/cneuromod_processed
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
-[submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
-	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
-	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/

--- a/.gitmodules
+++ b/.gitmodules
@@ -550,3 +550,6 @@
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
 
+[submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
+	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
+	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/


### PR DESCRIPTION
This PR manually adds the MICA-PNI-Precision-NeuroImaging-and-Connectomics dataset as a submodule, without the error seen in the version added by the crawler.