### PR TITLE
correcting description in eegnet_mfa DATS.json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -549,7 +549,6 @@
 	path = projects/cneuromod_processed
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
-
 [submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
 	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
 	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/

--- a/.gitmodules
+++ b/.gitmodules
@@ -549,6 +549,3 @@
 	path = projects/cneuromod_processed
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
-[submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
-	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
-	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/

--- a/.gitmodules
+++ b/.gitmodules
@@ -550,3 +550,6 @@
 	url = https://github.com/conpdatasets/cneuromod_processed
 	branch = main
 
+[submodule "projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics"]
+	path = projects/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics
+	url = https://github.com/conp-bot/conp-dataset-MICA-PNI-Precision-NeuroImaging-and-Connectomics/


### PR DESCRIPTION
This PR escapes a single-quote in the `description` field in the DATS.json file in the `eegnet_mfa` dataset, which was being erroneously read as an SQL field terminator during the archiving process.