### PR TITLE
manually adding another Zenodo dataset to test recent portal changes.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -552,3 +552,6 @@
 [submodule "projects/conp-dataset-Quantitative-T1-MRI"]
 	path = projects/conp-dataset-Quantitative-T1-MRI
 	url = https://github.com/CONP-PCNO/conp-dataset-Quantitative-T1-MRI
+[submodule "projects/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR"]
+	path = projects/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR
+	url = https://github.com/conp-bot/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR


### PR DESCRIPTION
This PR re-adds the "Paper is not enough" dataset originally added in https://github.com/CONP-PCNO/conp-dataset/pull/958 to test whether the changes in https://github.com/CONP-PCNO/conp-portal/pull/700 have fixed the issue with updates to CONP-PCNO/conp-dataset not filtering through to appear on https://portal.conp.ca/.