### PR TITLE
removed manual test conp-bot load

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -540,9 +540,6 @@
 [submodule "projects/conp-dataset-Quantitative-T1-MRI"]
 	path = projects/conp-dataset-Quantitative-T1-MRI
 	url = https://github.com/CONP-PCNO/conp-dataset-Quantitative-T1-MRI
-[submodule "projects/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR"]
-	path = projects/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR
-	url = https://github.com/conp-bot/conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISMR
 [submodule "projects/eegnet_ips"]
 	path = projects/eegnet_ips
 	url = https://github.com/conpdatasets/eegnet_ips


### PR DESCRIPTION
This PR removes the previous version of the `conp-dataset-Paper-is-not-enough-Crowdsourcing-the-T-sub-1-sub-mapping-common-ground-via-the-ISM` subdataset, which had been manually added as a workaround for conp-bot crawler problems, so that we can cleanly test the automated retrieval of this dataset in https://github.com/CONP-PCNO/conp-dataset/pull/993.