### PR TITLE
Fix zenodo crawler to comply with dats validation

### DIFF
--- a/scripts/Crawlers/BaseCrawler.py
+++ b/scripts/Crawlers/BaseCrawler.py
@@ -567,10 +567,12 @@ Functional checks:
         elif len(modalities) > 1 and "unknown" in modalities:
             modalities.remove("unknown")
         if "types" not in data.keys():
-            data["types"] = [{"value": modality} for modality in modalities]
+            data["types"] = [
+                {"information": {"value": modality}} for modality in modalities
+            ]
         else:
             for modality in modalities:
-                data["types"].append({"value": modality})
+                data["types"].append({"information": {"value": modality}})
 
         # Create file
         with open(dats_path, "w") as f:

--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -240,7 +240,9 @@ class ZenodoCrawler(BaseCrawler):
                             "size": dataset_size,
                             "unit": {"value": dataset_unit},
                             "access": {
-                                "landingPage": dataset.get("links", {}).get("html"),
+                                "landingPage": dataset.get("links", {}).get(
+                                    "self_html", "n/a"
+                                ),
                                 "authorizations": [
                                     {
                                         "value": "public"
@@ -256,10 +258,12 @@ class ZenodoCrawler(BaseCrawler):
                             "category": "logo",
                             "values": [
                                 {
-                                    "value": "https://about.zenodo.org/static/img/logos/zenodo-gradient-round.svg",
-                                },
+                                    "value": "https://about.zenodo.org/static/img/logos/zenodo-gradient-round.svg"
+                                }
                             ],
                         },
+                        {"category": "CONP_status", "values": [{"value": "Canadian"}]},
+                        {"category": "subjects", "values": [{"value": "unknown"}]},
                     ],
                     "dates": [
                         {


### PR DESCRIPTION
- adds required ExtraProperties:
```
{
                            "category": "CONP_status",
                            "values": [
                                {
                                    "value": "Canadian"
                                }
                            ]
                        },
	                {
                            "category": "subjects",
                            "values": [
                                {
                                    "value": "unknown"
                                }
                            ]
                        }
```
- fix a Zenodo API change breaking the landingPage population 
- fix the types format.