### PR TITLE
Replace multicenter-phantom with corrected version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -92,10 +92,6 @@
 [submodule "projects/calgary-campinas"]
 	path = projects/calgary-campinas
 	url = https://github.com/conpdatasets/calgary-campinas
-[submodule "projects/multicenter-phantom"]
-	path = projects/multicenter-phantom
-	url = https://github.com/conpdatasets/multicenter-phantom
-	branch = main
 [submodule "projects/BigBrain_3DROIs"]
 	path = projects/BigBrain_3DROIs
 	url = https://github.com/conpdatasets/BigBrain_3DROIs

--- a/.gitmodules
+++ b/.gitmodules
@@ -640,3 +640,4 @@
 [submodule "projects/multicenter-phantom"]
 	path = projects/multicenter-phantom
 	url = https://github.com/conpdatasets/multicenter-phantom
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -637,3 +637,6 @@
 	path = projects/A_steady_state_visual_evoked_potential__SSVEP__based_BCI_dataset_in_children_and_adolescents
 	url = https://github.com/conp-bot/conp-dataset-A-steady-state-visual-evoked-potential-SSVEP-based-BCI-dataset-in-children-and-adoles.git
 	datalad-id = 98b915ec-f2f9-4429-9c4d-9f7ddfc582ce
+[submodule "projects/multicenter-phantom"]
+	path = projects/multicenter-phantom
+	url = https://github.com/conpdatasets/multicenter-phantom


### PR DESCRIPTION
This PR replaces the previous multicenter-phantom with a recently recrawled version correcting non-functional links to all files of form PH1_*.