### PR TITLE
[Zenodo crawler] Record linked NeuroLibre/Evidence publication in DATS extraProperties

### DIFF
--- a/scripts/Crawlers/ZenodoCrawler.py
+++ b/scripts/Crawlers/ZenodoCrawler.py
@@ -193,6 +193,42 @@ class ZenodoCrawler(BaseCrawler):
                 else dataset["doi"]
             )
 
+            # Detect a linked NeuroLibre/Evidence publication.
+            # NeuroLibre/Evidence archives carry a related identifier of the
+            # form "isPartOf 10.55458/neurolibre.XXXXX" pointing to the
+            # publication that this dataset is part of.
+            evidence_publication_doi = None
+            for related in metadata.get("related_identifiers", []):
+                related_id = related.get("identifier", "")
+                if (
+                    related.get("relation", "").lower() == "ispartof"
+                    and "10.55458/" in related_id
+                ):
+                    evidence_publication_doi = related_id.replace(
+                        "https://doi.org/", ""
+                    )
+                    break
+
+            extra_properties = [
+                {
+                    "category": "logo",
+                    "values": [
+                        {
+                            "value": "https://about.zenodo.org/static/img/logos/zenodo-gradient-round.svg"
+                        }
+                    ],
+                },
+                {"category": "CONP_status", "values": [{"value": "Canadian"}]},
+                {"category": "subjects", "values": [{"value": "unknown"}]},
+            ]
+            if evidence_publication_doi:
+                extra_properties.append(
+                    {
+                        "category": "evidence_publication",
+                        "values": [{"value": evidence_publication_doi}],
+                    },
+                )
+
             # Get date created and date modified
             date_created = datetime.datetime.strptime(
                 dataset["created"],
@@ -253,18 +289,7 @@ class ZenodoCrawler(BaseCrawler):
                             },
                         },
                     ],
-                    "extraProperties": [
-                        {
-                            "category": "logo",
-                            "values": [
-                                {
-                                    "value": "https://about.zenodo.org/static/img/logos/zenodo-gradient-round.svg"
-                                }
-                            ],
-                        },
-                        {"category": "CONP_status", "values": [{"value": "Canadian"}]},
-                        {"category": "subjects", "values": [{"value": "unknown"}]},
-                    ],
+                    "extraProperties": extra_properties,
                     "dates": [
                         {
                             "date": date_created.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
NeuroLibre/Evidence stores every publication's dataset to Zenodo with a related identifier of the form `isPartOf → 10.55458/neurolibre.XXXXX`, pointing to the publication the dataset belongs to. This PR makes the Zenodo crawler capture that relation and write it into the dataset's DATS as an extra property:

```json
{ "category": "evidence_publication", "values": [ { "value": "10.55458/neurolibre.00007" } ] }
```

The CONP Portal will use this property to display a link from dataset cards/pages to the corresponding NeuroLibre/Evidence publication (companion PR in CONP-PCNO/conp-portal). Datasets without such a relation are unaffected — the property is simply absent.

## Notes

- Fully automatic: no manual curation; every future Evidence publication inherits the link on crawl.
- Verified against live Zenodo records (e.g. record 6463435 carries `isPartOf 10.55458/neurolibre.00004`).
- The DOI is stored bare (no `https://doi.org/` prefix); consumers construct the URL.
- Out of scope, noted for follow-up: recent crawled titles carry a literal "(Dataset)" prefix from the Zenodo record title. Stripping it changes the slugified project directory name for existing datasets, so it needs a small migration and is deliberately not done here.
